### PR TITLE
Fix bytes read in get_zoom_block_values

### DIFF
--- a/src/bbi/bbiread.rs
+++ b/src/bbi/bbiread.rs
@@ -204,7 +204,6 @@ pub trait BBIRead {
         end: u32,
     ) -> Result<Vec<Block>, CirTreeSearchError> {
         let full_index_offset = self.get_info().header.full_index_offset;
-
         self.search_cir_tree(full_index_offset, chrom_name, start, end)
     }
 }
@@ -745,9 +744,8 @@ pub(crate) fn get_zoom_block_values<B: BBIRead>(
 
     let endianness = bbifile.get_info().header.endianness;
 
-    let mut bytes = BytesMut::zeroed(itemcount * 64);
+    let mut bytes = BytesMut::zeroed(itemcount * (4 * 8));
     data_mut.read_exact(&mut bytes)?;
-
     match endianness {
         Endianness::Big => {
             for _ in 0..itemcount {

--- a/src/bbi/bigwigread.rs
+++ b/src/bbi/bigwigread.rs
@@ -331,7 +331,9 @@ where
         };
 
         let index_offset = zoom_header.index_offset;
+
         let blocks = self.search_cir_tree(index_offset, chrom_name, start, end)?;
+
         Ok(ZoomIntervalIter::new(
             self,
             blocks.into_iter(),

--- a/tests/bigwigread.rs
+++ b/tests/bigwigread.rs
@@ -57,3 +57,23 @@ fn test_values() -> Result<(), Box<dyn Error>> {
     assert_eq!(vals[59898], 0.06792);
     Ok(())
 }
+
+#[test]
+fn test_reduction_values() -> Result<(), Box<dyn Error>> {
+    use std::path::PathBuf;
+
+    use bigtools::bbi::BigWigRead;
+
+    let mut dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    dir.push("resources/test");
+
+    let mut valid_bigwig = dir.clone();
+    valid_bigwig.push("valid.bigWig");
+
+    let mut bwread = BigWigRead::open_file(&valid_bigwig.to_string_lossy()).unwrap();
+    let interval = bwread.get_zoom_interval("chr17", 0, 36996442, 10240);
+    let x: Vec<_> = interval.unwrap().collect();
+
+    assert_eq!(x.len(), 16);
+    Ok(())
+}


### PR DESCRIPTION
`get_zoom_block_values` was trying to read `itemcount * 64` bytes from `data_mut`, but `data_mut` is only `itemcount * 64` bytes long.

Changed the # of bytes read and added a test to verify. Without this change the test errors out with

`[Err(IoError(Error { kind: UnexpectedEof, message: "failed to fill whole buffer" }))]`