### PR TITLE
Make sure license file is bundled with sdist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+dist/
 **/target
 **/*.rs.bk
 **/__pycache__

--- a/bigtools/LICENSE
+++ b/bigtools/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Jack Huey
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pybigtools/LICENSE
+++ b/pybigtools/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Jack Huey
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pybigtools/pyproject.toml
+++ b/pybigtools/pyproject.toml
@@ -2,12 +2,19 @@
 requires = ["maturin>=1.0,<2.0"]
 build-backend = "maturin"
 
-[tools.maturin]
+[tool.maturin]
 bindings = "cffi"
 compatibility = "linux"
 
 [project]
 name = "pybigtools"
+description = "Python bindings to the Bigtools Rust library for high-performance BigWig and BigBed I/O"
+license = { text = "MIT" }
 dependencies = [
     "numpy"
 ]
+
+[project.urls]
+homepage = "https://github.com/jackh726/bigtools"
+documentation = "https://bigtools.readthedocs.io"
+repository = "https://github.com/jackh726/bigtools"


### PR DESCRIPTION
I added some metadata to `pyproject.toml` and copied the license file to the pybigtools directory so that maturin bundles it when it creates the sdist. Adding the SPDX identifier line to pyproject.toml seems to be enough to make maturin find and include the file when running `maturin sdist`.

Bioconda expects to see a license file and is currently failing to build pybigtools because it is missing from the sdist.
