### PR TITLE
Specialized Python exceptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,9 @@ jobs:
     
       - name: Install pybigtools
         run: |
-          pip install maturin pytest
+          pip install maturin
           cd pybigtools
-          pip install -e .
+          pip install -e .[test]
   
       - name: Install
         run: |

--- a/pybigtools/pyproject.toml
+++ b/pybigtools/pyproject.toml
@@ -6,8 +6,32 @@ build-backend = "maturin"
 name = "pybigtools"
 description = "Python bindings to the Bigtools Rust library for high-performance BigWig and BigBed I/O"
 license = { text = "MIT" }
+keywords = [
+    "bigwig",
+    "bigbed",
+    "bbi",
+    "bioinformatics",
+    "genomics",
+    "kent",
+    "ucsc",
+    "rust",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Operating System :: OS Independent",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+    "Programming Language :: Rust",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+]
 dependencies = [
     "numpy"
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "smart_open[http]"
 ]
 
 [project.urls]

--- a/pybigtools/src/lib.rs
+++ b/pybigtools/src/lib.rs
@@ -1425,7 +1425,7 @@ impl BBIRead {
     /// records : Get the records of a given range on a chromosome.
     /// zoom_records : Get the zoom records of a given range on a chromosome.
     #[pyo3(
-        signature = (chrom, start, end, bins=None, summary="mean".to_string(), exact=false, missing=0.0, oob=f64::NAN, arr=None),
+        signature = (chrom, start=None, end=None, bins=None, summary="mean".to_string(), exact=false, missing=0.0, oob=f64::NAN, arr=None),
         text_signature = r#"(chrom, start, end, bins=None, summary="mean", exact=False, missing=0.0, oob=..., arr=None)"#,
     )]
     fn values(

--- a/pybigtools/src/lib.rs
+++ b/pybigtools/src/lib.rs
@@ -37,8 +37,18 @@ mod file_like;
 
 type ValueTuple = (u32, u32, f32);
 
-create_exception!(pybigtools, BBIFileClosed, exceptions::PyException);
-create_exception!(pybigtools, BBIReadError, exceptions::PyException);
+create_exception!(
+    pybigtools,
+    BBIFileClosed,
+    exceptions::PyException,
+    "BBI File is closed."
+);
+create_exception!(
+    pybigtools,
+    BBIReadError,
+    exceptions::PyException,
+    "Error reading BBI file."
+);
 
 fn start_end(
     bbi: &BBIReadRaw,
@@ -209,7 +219,7 @@ fn intervals_to_array<R: BBIFileRead>(
         Some(bins) => {
             if v.len() != bins {
                 return Err(PyErr::new::<exceptions::PyValueError, _>(format!(
-                    "`arr` does not the expected size (expected `{}`, found `{}`), if passed.",
+                    "`arr` does not have the expected size (expected `{}`, found `{}`), if passed.",
                     bins,
                     v.len(),
                 )));
@@ -303,6 +313,7 @@ fn intervals_to_array<R: BBIFileRead>(
 
     Ok(arr)
 }
+
 fn entries_to_array<R: BBIFileRead>(
     py: Python<'_>,
     b: &mut BigBedReadRaw<R>,
@@ -458,6 +469,7 @@ fn to_array<I: Iterator<Item = Result<Value, _BBIReadError>>>(
     }
     Ok(())
 }
+
 fn to_array_bins<I: Iterator<Item = Result<Value, _BBIReadError>>>(
     start: i32,
     end: i32,
@@ -564,6 +576,7 @@ fn to_array_bins<I: Iterator<Item = Result<Value, _BBIReadError>>>(
     }
     Ok(())
 }
+
 fn to_array_zoom<I: Iterator<Item = Result<ZoomRecord, _BBIReadError>>>(
     start: i32,
     end: i32,
@@ -681,6 +694,7 @@ fn to_array_zoom<I: Iterator<Item = Result<ZoomRecord, _BBIReadError>>>(
     }
     Ok(())
 }
+
 fn to_entry_array<I: Iterator<Item = Result<BedEntry, _BBIReadError>>>(
     start: i32,
     end: i32,
@@ -700,6 +714,7 @@ fn to_entry_array<I: Iterator<Item = Result<BedEntry, _BBIReadError>>>(
     }
     Ok(())
 }
+
 fn to_entry_array_bins<I: Iterator<Item = Result<BedEntry, _BBIReadError>>>(
     start: i32,
     end: i32,

--- a/pybigtools/src/lib.rs
+++ b/pybigtools/src/lib.rs
@@ -2123,6 +2123,13 @@ fn open(py: Python, path_url_or_file_like: PyObject, mode: Option<String>) -> Py
         return open_path_or_url(py, string_ref.to_str().unwrap().to_owned(), iswrite);
     }
 
+    // If pathlib.Path, convert to string and try to open
+    let path_class = py.import("pathlib")?.getattr("Path")?;
+    if path_url_or_file_like.as_ref(py).is_instance(path_class)? {
+        let path_str = path_url_or_file_like.as_ref(py).str()?.to_str()?;
+        return open_path_or_url(py, path_str.to_owned(), iswrite);
+    }
+
     if iswrite {
         return Err(PyErr::new::<exceptions::PyValueError, _>(format!(
             "Writing only supports file names",

--- a/pybigtools/src/lib.rs
+++ b/pybigtools/src/lib.rs
@@ -16,7 +16,7 @@ use bigtools::utils::misc::{
     bigwig_average_over_bed, BigWigAverageOverBedEntry, BigWigAverageOverBedError, Name,
 };
 use bigtools::{
-    BBIFileRead, BBIReadError, BedEntry, BigBedRead as BigBedReadRaw,
+    BBIFileRead, BBIReadError as _BBIReadError, BedEntry, BigBedRead as BigBedReadRaw,
     BigBedWrite as BigBedWriteRaw, BigWigRead as BigWigReadRaw, BigWigWrite as BigWigWriteRaw,
     CachedBBIFileRead, Value, ZoomRecord,
 };
@@ -38,6 +38,8 @@ mod file_like;
 type ValueTuple = (u32, u32, f32);
 
 create_exception!(pybigtools, BBIFileClosed, exceptions::PyException);
+create_exception!(pybigtools, BBIReadError, exceptions::PyException);
+
 
 fn start_end(
     bbi: &BBIReadRaw,
@@ -59,7 +61,7 @@ fn start_end(
     let chrom = chroms.into_iter().find(|x| x.name == chrom_name);
     let length = match chrom {
         None => {
-            return Err(PyErr::new::<exceptions::PyException, _>(format!(
+            return Err(PyErr::new::<exceptions::PyKeyError, _>(format!(
                 "No chromomsome with name `{}` found.",
                 chrom_name
             )))
@@ -101,7 +103,7 @@ fn start_end_length_inner(
     let chrom = chroms.into_iter().find(|x| x.name == chrom_name);
     let length = match chrom {
         None => {
-            return Err(PyErr::new::<exceptions::PyException, _>(format!(
+            return Err(PyErr::new::<exceptions::PyKeyError, _>(format!(
                 "No chromomsome with name `{}` found.",
                 chrom_name
             )))
@@ -140,14 +142,19 @@ trait ToPyErr {
     fn to_py_err(self) -> PyErr;
 }
 
-impl ToPyErr for bigtools::ZoomIntervalError {
-    fn to_py_err(self) -> PyErr {
-        PyErr::new::<exceptions::PyException, _>(format!("{}", self))
-    }
-}
 impl ToPyErr for bigtools::BBIReadError {
     fn to_py_err(self) -> PyErr {
-        PyErr::new::<exceptions::PyException, _>(format!("{}", self))
+        PyErr::new::<BBIReadError, _>(format!("{}", self))
+    }
+}
+impl ToPyErr for bigtools::ZoomIntervalError {
+    fn to_py_err(self) -> PyErr {
+        match self {
+            bigtools::ZoomIntervalError::ReductionLevelNotFound => PyErr::new::<exceptions::PyKeyError, _>(
+                format!("The passed reduction level was not found")
+            ),
+            _ => PyErr::new::<BBIReadError, _>(format!("{}", self))
+        }
     }
 }
 
@@ -192,7 +199,7 @@ fn intervals_to_array<R: BBIFileRead>(
         (None, None) => PyArray1::from_vec(py, vec![missing; (end - start) as usize]).to_object(py),
     };
     let v: &PyArray1<f64> = arr.downcast::<PyArray1<f64>>(py).map_err(|_| {
-        PyErr::new::<exceptions::PyException, _>(
+        PyErr::new::<exceptions::PyValueError, _>(
             "`arr` option must be a one-dimensional numpy array, if passed.",
         )
     })?;
@@ -200,7 +207,7 @@ fn intervals_to_array<R: BBIFileRead>(
     let bin_size = match bins {
         Some(bins) => {
             if v.len() != bins {
-                return Err(PyErr::new::<exceptions::PyException, _>(format!(
+                return Err(PyErr::new::<exceptions::PyValueError, _>(format!(
                     "`arr` does not the expected size (expected `{}`, found `{}`), if passed.",
                     bins,
                     v.len(),
@@ -251,8 +258,8 @@ fn intervals_to_array<R: BBIFileRead>(
         }
         _ => {
             if v.len() != (end - start) as usize {
-                return Err(PyErr::new::<exceptions::PyException, _>(format!(
-                    "`arr` does not the expected size (expected `{}`, found `{}`), if passed.",
+                return Err(PyErr::new::<exceptions::PyValueError, _>(format!(
+                    "`arr` does not have the expected size (expected `{}`, found `{}`), if passed.",
                     (end - start) as usize,
                     v.len(),
                 )));
@@ -327,7 +334,7 @@ fn entries_to_array<R: BBIFileRead>(
         (None, None) => PyArray1::from_vec(py, vec![missing; (end - start) as usize]).to_object(py),
     };
     let v: &PyArray1<f64> = arr.downcast::<PyArray1<f64>>(py).map_err(|_| {
-        PyErr::new::<exceptions::PyException, _>(
+        PyErr::new::<exceptions::PyValueError, _>(
             "`arr` option must be a one-dimensional numpy array, if passed.",
         )
     })?;
@@ -335,8 +342,8 @@ fn entries_to_array<R: BBIFileRead>(
     let bin_size = match bins {
         Some(bins) => {
             if v.len() != bins {
-                return Err(PyErr::new::<exceptions::PyException, _>(format!(
-                    "`arr` does not the expected size (expected `{}`, found `{}`), if passed.",
+                return Err(PyErr::new::<exceptions::PyValueError, _>(format!(
+                    "`arr` does not have the expected size (expected `{}`, found `{}`), if passed.",
                     bins,
                     v.len(),
                 )));
@@ -386,8 +393,8 @@ fn entries_to_array<R: BBIFileRead>(
         }
         _ => {
             if v.len() != (end - start) as usize {
-                return Err(PyErr::new::<exceptions::PyException, _>(format!(
-                    "`arr` does not the expected size (expected `{}`, found `{}`), if passed.",
+                return Err(PyErr::new::<exceptions::PyValueError, _>(format!(
+                    "`arr` does not have the expected size (expected `{}`, found `{}`), if passed.",
                     (end - start) as usize,
                     v.len(),
                 )));
@@ -431,13 +438,13 @@ fn entries_to_array<R: BBIFileRead>(
     Ok(arr)
 }
 
-fn to_array<I: Iterator<Item = Result<Value, BBIReadError>>>(
+fn to_array<I: Iterator<Item = Result<Value, _BBIReadError>>>(
     start: i32,
     end: i32,
     iter: I,
     missing: f64,
     mut v: ArrayViewMut<'_, f64, numpy::Ix1>,
-) -> Result<(), BBIReadError> {
+) -> Result<(), _BBIReadError> {
     assert_eq!(v.len(), (end - start) as usize);
     v.fill(missing);
     for interval in iter {
@@ -450,7 +457,7 @@ fn to_array<I: Iterator<Item = Result<Value, BBIReadError>>>(
     }
     Ok(())
 }
-fn to_array_bins<I: Iterator<Item = Result<Value, BBIReadError>>>(
+fn to_array_bins<I: Iterator<Item = Result<Value, _BBIReadError>>>(
     start: i32,
     end: i32,
     iter: I,
@@ -458,7 +465,7 @@ fn to_array_bins<I: Iterator<Item = Result<Value, BBIReadError>>>(
     bins: usize,
     missing: f64,
     mut v: ArrayViewMut<'_, f64, numpy::Ix1>,
-) -> Result<(), BBIReadError> {
+) -> Result<(), _BBIReadError> {
     assert_eq!(v.len(), bins);
     v.fill(missing);
 
@@ -556,7 +563,7 @@ fn to_array_bins<I: Iterator<Item = Result<Value, BBIReadError>>>(
     }
     Ok(())
 }
-fn to_array_zoom<I: Iterator<Item = Result<ZoomRecord, BBIReadError>>>(
+fn to_array_zoom<I: Iterator<Item = Result<ZoomRecord, _BBIReadError>>>(
     start: i32,
     end: i32,
     iter: I,
@@ -564,7 +571,7 @@ fn to_array_zoom<I: Iterator<Item = Result<ZoomRecord, BBIReadError>>>(
     bins: usize,
     missing: f64,
     mut v: ArrayViewMut<'_, f64, numpy::Ix1>,
-) -> Result<(), BBIReadError> {
+) -> Result<(), _BBIReadError> {
     assert_eq!(v.len(), bins);
     v.fill(missing);
 
@@ -673,13 +680,13 @@ fn to_array_zoom<I: Iterator<Item = Result<ZoomRecord, BBIReadError>>>(
     }
     Ok(())
 }
-fn to_entry_array<I: Iterator<Item = Result<BedEntry, BBIReadError>>>(
+fn to_entry_array<I: Iterator<Item = Result<BedEntry, _BBIReadError>>>(
     start: i32,
     end: i32,
     iter: I,
     missing: f64,
     mut v: ArrayViewMut<'_, f64, numpy::Ix1>,
-) -> Result<(), BBIReadError> {
+) -> Result<(), _BBIReadError> {
     assert_eq!(v.len(), (end - start) as usize);
     v.fill(missing);
     for interval in iter {
@@ -692,7 +699,7 @@ fn to_entry_array<I: Iterator<Item = Result<BedEntry, BBIReadError>>>(
     }
     Ok(())
 }
-fn to_entry_array_bins<I: Iterator<Item = Result<BedEntry, BBIReadError>>>(
+fn to_entry_array_bins<I: Iterator<Item = Result<BedEntry, _BBIReadError>>>(
     start: i32,
     end: i32,
     iter: I,
@@ -700,7 +707,7 @@ fn to_entry_array_bins<I: Iterator<Item = Result<BedEntry, BBIReadError>>>(
     bins: usize,
     missing: f64,
     mut v: ArrayViewMut<'_, f64, numpy::Ix1>,
-) -> Result<(), BBIReadError> {
+) -> Result<(), _BBIReadError> {
     assert_eq!(v.len(), bins);
     v.fill(missing);
 
@@ -806,7 +813,7 @@ fn to_entry_array_bins<I: Iterator<Item = Result<BedEntry, BBIReadError>>>(
     Ok(())
 }
 
-fn to_entry_array_zoom<I: Iterator<Item = Result<ZoomRecord, BBIReadError>>>(
+fn to_entry_array_zoom<I: Iterator<Item = Result<ZoomRecord, _BBIReadError>>>(
     start: i32,
     end: i32,
     iter: I,
@@ -814,7 +821,7 @@ fn to_entry_array_zoom<I: Iterator<Item = Result<ZoomRecord, BBIReadError>>>(
     bins: usize,
     missing: f64,
     mut v: ArrayViewMut<'_, f64, numpy::Ix1>,
-) -> Result<(), BBIReadError> {
+) -> Result<(), _BBIReadError> {
     assert_eq!(v.len(), bins);
     v.fill(missing);
 
@@ -1088,10 +1095,10 @@ impl BBIRead {
         };
         let obj = if parse {
             let mut declarations = parse_autosql(&schema).map_err(|_| {
-                PyErr::new::<exceptions::PyException, _>("Unable to parse autosql.")
+                PyErr::new::<BBIReadError, _>("Unable to parse autosql.")
             })?;
             if declarations.len() > 1 {
-                return Err(PyErr::new::<exceptions::PyException, _>(
+                return Err(PyErr::new::<BBIReadError, _>(
                     "Unexpected extra declarations.",
                 ));
             }
@@ -1305,7 +1312,7 @@ impl BBIRead {
             "min" => Summary::Min,
             "max" => Summary::Max,
             _ => {
-                return Err(PyErr::new::<exceptions::PyException, _>(format!(
+                return Err(PyErr::new::<exceptions::PyValueError, _>(format!(
                     "Unrecognized summary. Only `mean`, `min`, and `max` are allowed."
                 )));
             }
@@ -1415,7 +1422,7 @@ impl BBIRead {
                     Err(_) => match names.extract::<isize>(py) {
                         Ok(col) => {
                             if col < 0 {
-                                return Err(PyErr::new::<exceptions::PyException, _>(
+                                return Err(PyErr::new::<exceptions::PyValueError, _>(
                                     "Invalid names argument. Must be >= 0.",
                                 ));
                             }
@@ -1426,7 +1433,7 @@ impl BBIRead {
                             }
                         }
                         Err(_) => {
-                            return Err(PyErr::new::<exceptions::PyException, _>("Invalid names argument. Should be either `None`, a `bool`, or an `int`"));
+                            return Err(PyErr::new::<exceptions::PyValueError, _>("Invalid names argument. Should be either `None`, a `bool`, or an `int`"));
                         }
                     },
                 },
@@ -1499,7 +1506,7 @@ impl BBIRead {
 
 #[pyclass(module = "pybigtools")]
 struct ZoomIntervalIterator {
-    iter: Box<dyn Iterator<Item = Result<ZoomRecord, BBIReadError>> + Send>,
+    iter: Box<dyn Iterator<Item = Result<ZoomRecord, _BBIReadError>> + Send>,
 }
 
 #[pymethods]
@@ -1536,7 +1543,7 @@ impl ZoomIntervalIterator {
 /// any missing intervals.
 #[pyclass(module = "pybigtools")]
 struct BigWigIntervalIterator {
-    iter: Box<dyn Iterator<Item = Result<Value, BBIReadError>> + Send>,
+    iter: Box<dyn Iterator<Item = Result<Value, _BBIReadError>> + Send>,
 }
 
 #[pymethods]
@@ -1557,7 +1564,7 @@ impl BigWigIntervalIterator {
 /// This class is an interator for the entries in a bigBed file.
 #[pyclass(module = "pybigtools")]
 struct BigBedEntriesIterator {
-    iter: Box<dyn Iterator<Item = Result<BedEntry, BBIReadError>> + Send>,
+    iter: Box<dyn Iterator<Item = Result<BedEntry, _BBIReadError>> + Send>,
 }
 
 #[pymethods]
@@ -1608,7 +1615,7 @@ impl BigWigWrite {
         let bigwig = self
             .bigwig
             .take()
-            .ok_or_else(|| PyErr::new::<exceptions::PyException, _>("File already closed."))?;
+            .ok_or_else(|| PyErr::new::<BBIFileClosed, _>("File already closed."))?;
         let chrom_map = chroms
             .into_iter()
             .map(|(key, val)| {
@@ -1746,7 +1753,7 @@ impl BigBedWrite {
         let bigbed = self
             .bigbed
             .take()
-            .ok_or_else(|| PyErr::new::<exceptions::PyException, _>("File already closed."))?;
+            .ok_or_else(|| PyErr::new::<BBIFileClosed, _>("File already closed."))?;
         let chrom_map = chroms
             .into_iter()
             .map(|(key, val)| {
@@ -1933,7 +1940,7 @@ fn open(py: Python, path_url_or_file_like: PyObject, mode: Option<String>) -> Py
         Some(mode) if mode == "r" => false,
         None => false,
         Some(mode) => {
-            return Err(PyErr::new::<exceptions::PyException, _>(format!(
+            return Err(PyErr::new::<exceptions::PyValueError, _>(format!(
                 "Invalid mode: `{}`",
                 mode
             )));
@@ -1946,13 +1953,13 @@ fn open(py: Python, path_url_or_file_like: PyObject, mode: Option<String>) -> Py
     }
 
     if iswrite {
-        return Err(PyErr::new::<exceptions::PyException, _>(format!(
+        return Err(PyErr::new::<exceptions::PyValueError, _>(format!(
             "Writing only supports file names",
         )));
     }
     let file_like = match PyFileLikeObject::new(path_url_or_file_like, true, false, true) {
         Ok(file_like) => file_like,
-        Err(_) => return Err(PyErr::new::<exceptions::PyException, _>(format!(
+        Err(_) => return Err(PyErr::new::<exceptions::PyValueError, _>(format!(
             "Unknown argument for `path_url_or_file_like`. Not a file path string or url, and not a file-like object.",
         ))),
     };
@@ -1967,7 +1974,7 @@ fn open(py: Python, path_url_or_file_like: PyObject, mode: Option<String>) -> Py
             }
             .into_py(py),
             Err(e) => {
-                return Err(PyErr::new::<exceptions::PyException, _>(format!(
+                return Err(PyErr::new::<BBIReadError, _>(format!(
                     "File-like object is not a bigWig or bigBed. Or there was just a problem reading: {e}",
                 )))
             }
@@ -1987,13 +1994,13 @@ fn open_path_or_url(
     {
         Some(e) => e.to_string(),
         None => {
-            return Err(PyErr::new::<exceptions::PyException, _>(format!("Invalid file type. Must be either a bigWig (.bigWig, .bw) or bigBed (.bigBed, .bb).")));
+            return Err(PyErr::new::<exceptions::PyValueError, _>(format!("Invalid file type. Must be either a bigWig (.bigWig, .bw) or bigBed (.bigBed, .bb).")));
         }
     };
     let res = if iswrite {
         match Url::parse(&path_url_or_file_like) {
             Ok(_) => {
-                return Err(PyErr::new::<exceptions::PyException, _>(format!(
+                return Err(PyErr::new::<exceptions::PyValueError, _>(format!(
                     "Invalid file path. Writing does not support urls."
                 )))
             }
@@ -2009,7 +2016,7 @@ fn open_path_or_url(
             }
             .into_py(py),
             _ => {
-                return Err(PyErr::new::<exceptions::PyException, _>(format!("Invalid file type. Must be either a bigWig (.bigWig, .bw) or bigBed (.bigBed, .bb).")));
+                return Err(PyErr::new::<exceptions::PyValueError, _>(format!("Invalid file type. Must be either a bigWig (.bigWig, .bw) or bigBed (.bigBed, .bb).")));
             }
         }
     } else {
@@ -2018,8 +2025,8 @@ fn open_path_or_url(
             match Url::parse(&path_url_or_file_like) {
                 Ok(_) => {}
                 Err(_) => {
-                    return Err(PyErr::new::<exceptions::PyException, _>(format!(
-                        "Invalid file path. The file does not exists and it is not a url."
+                    return Err(PyErr::new::<exceptions::PyValueError, _>(format!(
+                        "Invalid file path. The file does not exist and it is not a url."
                     )))
                 }
             }
@@ -2033,7 +2040,7 @@ fn open_path_or_url(
                         }
                         .into_py(py),
                         Err(_) => {
-                            return Err(PyErr::new::<exceptions::PyException, _>(format!(
+                            return Err(PyErr::new::<BBIReadError, _>(format!(
                                 "Error opening bigWig."
                             )))
                         }
@@ -2046,7 +2053,7 @@ fn open_path_or_url(
                         }
                         .into_py(py),
                         Err(_) => {
-                            return Err(PyErr::new::<exceptions::PyException, _>(format!(
+                            return Err(PyErr::new::<BBIReadError, _>(format!(
                                 "Error opening bigWig."
                             )))
                         }
@@ -2054,7 +2061,7 @@ fn open_path_or_url(
 
                     #[cfg(not(feature = "remote"))]
                     {
-                        return Err(PyErr::new::<exceptions::PyException, _>(format!(
+                        return Err(PyErr::new::<exceptions::PyOSError, _>(format!(
                             "Builtin support for remote files is not supported on this platform."
                         )));
                     }
@@ -2068,7 +2075,7 @@ fn open_path_or_url(
                         }
                         .into_py(py),
                         Err(_) => {
-                            return Err(PyErr::new::<exceptions::PyException, _>(format!(
+                            return Err(PyErr::new::<BBIReadError, _>(format!(
                                 "Error opening bigBed."
                             )))
                         }
@@ -2081,7 +2088,7 @@ fn open_path_or_url(
                         }
                         .into_py(py),
                         Err(_) => {
-                            return Err(PyErr::new::<exceptions::PyException, _>(format!(
+                            return Err(PyErr::new::<BBIReadError, _>(format!(
                                 "Error opening bigBed."
                             )))
                         }
@@ -2089,14 +2096,14 @@ fn open_path_or_url(
 
                     #[cfg(not(feature = "remote"))]
                     {
-                        return Err(PyErr::new::<exceptions::PyException, _>(format!(
+                        return Err(PyErr::new::<exceptions::PyOSError, _>(format!(
                             "Builtin support for remote files is not supported on this platform."
                         )));
                     }
                 }
             }
             _ => {
-                return Err(PyErr::new::<exceptions::PyException, _>(format!("Invalid file type. Must be either a bigWig (.bigWig, .bw) or bigBed (.bigBed, .bb).")));
+                return Err(PyErr::new::<exceptions::PyValueError, _>(format!("Invalid file type. Must be either a bigWig (.bigWig, .bw) or bigBed (.bigBed, .bb).")));
             }
         }
     };
@@ -2133,7 +2140,7 @@ fn bigWigAverageOverBed(
     let extension = match &Path::new(&bigwig).extension().map(|e| e.to_string_lossy()) {
         Some(e) => e.to_string(),
         None => {
-            return Err(PyErr::new::<exceptions::PyException, _>(format!(
+            return Err(PyErr::new::<exceptions::PyValueError, _>(format!(
                 "Invalid file type. Must be a bigWig (.bigWig, .bw)."
             )));
         }
@@ -2143,7 +2150,7 @@ fn bigWigAverageOverBed(
         match Url::parse(&bigwig) {
             Ok(_) => {}
             Err(_) => {
-                return Err(PyErr::new::<exceptions::PyException, _>(format!(
+                return Err(PyErr::new::<exceptions::PyValueError, _>(format!(
                     "Invalid file path. The file does not exists and it is not a url."
                 )))
             }
@@ -2162,7 +2169,7 @@ fn bigWigAverageOverBed(
                 Err(_) => match names.extract::<isize>(py) {
                     Ok(col) => {
                         if col < 0 {
-                            return Err(PyErr::new::<exceptions::PyException, _>(
+                            return Err(PyErr::new::<exceptions::PyValueError, _>(
                                 "Invalid names argument. Must be >= 0.",
                             ));
                         }
@@ -2173,7 +2180,7 @@ fn bigWigAverageOverBed(
                         }
                     }
                     Err(_) => {
-                        return Err(PyErr::new::<exceptions::PyException, _>("Invalid names argument. Should be either `None`, a `bool`, or an `int`"));
+                        return Err(PyErr::new::<exceptions::PyValueError, _>("Invalid names argument. Should be either `None`, a `bool`, or an `int`"));
                     }
                 },
             },
@@ -2185,7 +2192,7 @@ fn bigWigAverageOverBed(
             if isfile {
                 let read = BigWigReadRaw::open_file(&bigwig)
                     .map_err(|_| {
-                        PyErr::new::<exceptions::PyException, _>(format!("Error opening bigWig."))
+                        PyErr::new::<BBIReadError, _>(format!("Error opening bigWig."))
                     })?
                     .cached();
                 let bedin = BufReader::new(File::open(bed)?);
@@ -2197,7 +2204,7 @@ fn bigWigAverageOverBed(
                 {
                     let read = BigWigReadRaw::open(RemoteFile::new(&bigwig))
                         .map_err(|_| {
-                            PyErr::new::<exceptions::PyException, _>(format!(
+                            PyErr::new::<BBIReadError, _>(format!(
                                 "Error opening bigBed."
                             ))
                         })?
@@ -2210,14 +2217,14 @@ fn bigWigAverageOverBed(
 
                 #[cfg(not(feature = "remote"))]
                 {
-                    return Err(PyErr::new::<exceptions::PyException, _>(format!(
+                    return Err(PyErr::new::<exceptions::PyOSError, _>(format!(
                         "Builtin support for remote files is not available on this platform."
                     )));
                 }
             }
         }
         _ => {
-            return Err(PyErr::new::<exceptions::PyException, _>(format!(
+            return Err(PyErr::new::<exceptions::PyValueError, _>(format!(
                 "Invalid file type. Must be a bigWig (.bigWig, .bw)."
             )));
         }
@@ -2230,6 +2237,7 @@ fn bigWigAverageOverBed(
 #[pymodule]
 fn pybigtools(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add("BBIFileClosed", m.py().get_type::<BBIFileClosed>())?;
+    m.add("BBIReadError", m.py().get_type::<BBIReadError>())?;
 
     m.add_wrapped(wrap_pyfunction!(open))?;
     m.add_wrapped(wrap_pyfunction!(bigWigAverageOverBed))?;

--- a/pybigtools/tests/test_api.py
+++ b/pybigtools/tests/test_api.py
@@ -74,9 +74,9 @@ def test_chroms(bw, bb):
     assert bw.chroms("chr17") == 83257441
     assert bb.chroms("chr21") == 48129895
 
-    # Missing chrom => None
-    assert bw.chroms("chr11") is None
-    assert bb.chroms("chr11") is None
+    # Missing chrom => KeyError
+    pytest.raises(KeyError, bw.chroms, "chr11")
+    pytest.raises(KeyError, bb.chroms, "chr11")
 
 
 def test_zooms(bw, bb):

--- a/pybigtools/tests/test_api.py
+++ b/pybigtools/tests/test_api.py
@@ -1,111 +1,291 @@
-import pybigtools
 import math
+import pathlib
+from io import BytesIO
+
 import numpy as np
+import pytest
 
-def test_api():
-    b = pybigtools.open('../bigtools/resources/test/valid.bigWig', 'r')
+import pybigtools
 
-    # Check type of file
-    assert b.is_bigbed == False
-    assert b.is_bigwig == True
+TEST_DIR = pathlib.Path(__file__).parent
+REPO_ROOT = TEST_DIR.parent.parent
 
+
+def test_open_close():
+    path = str(REPO_ROOT / "bigtools/resources/test/valid.bigWig")
+    b = pybigtools.open(path, "r")
+    b.close()
+    assert pytest.raises(pybigtools.BBIFileClosed, b.chroms)
+
+    # Files are closed when exiting a context manager
+    with pybigtools.open(path, "r") as b:
+        pass
+    assert pytest.raises(pybigtools.BBIFileClosed, b.chroms)
+
+    # Invalid file-like object
+    s = BytesIO()
+    assert pytest.raises(pybigtools.BBIReadError, pybigtools.open, s, "r")
+
+
+@pytest.fixture
+def bw():
+    path = str(REPO_ROOT / "bigtools/resources/test/valid.bigWig")
+    return pybigtools.open(path, "r")
+
+
+@pytest.fixture
+def bb():
+    path = str(TEST_DIR / "data/bigBedExample.bb")
+    return pybigtools.open(path, "r")
+
+
+def test_check_filetype(bw, bb):
+    assert not bw.is_bigbed
+    assert bw.is_bigwig
+
+    assert bb.is_bigbed
+    assert not bb.is_bigwig
+
+
+def test_info(bw):
+    assert bw.info() == {
+        'version': 4,
+        'isCompressed': True,
+        'primaryDataSize': 603305,
+        'zoomLevels': 10,
+        'chromCount': 1,
+        'summary': {
+            'basesCovered': 137894,
+            'sum': 89001714.97238067,
+            'mean': 645.4357330440822,
+            'min': 0.006219999864697456,
+            'max': 14254.0,
+            'std': 751.0146556298351
+        },
+    }
+
+
+def test_chroms(bw, bb):
     # No args => dict
-    assert b.chroms() == {'chr17': 83257441}
+    assert bw.chroms() == {"chr17": 83_257_441}
+    assert bb.chroms() == {"chr21": 48_129_895}
+
     # Arg with chrom name => length
-    assert b.chroms('chr17') == 83257441
+    assert bw.chroms("chr17") == 83257441
+    assert bb.chroms("chr21") == 48129895
+
     # Missing chrom => None
-    assert b.chroms('chr11') == None
+    assert bw.chroms("chr11") is None
+    assert bb.chroms("chr11") is None
 
+
+def test_zooms(bw, bb):
     # Get a list of zooms
-    assert b.zooms() == [10, 40, 160, 640, 2560, 10240, 40960, 163840, 655360, 2621440]
+    assert bw.zooms() == [10, 40, 160, 640, 2560, 10240, 40960, 163840, 655360, 2621440]
+    assert bb.zooms() == [3911, 39110, 391100, 3911000, 39110000]
 
+
+def test_autosql(bw, bb):
     # Even bigwigs have sql (a sql representing bedGraph)
-    assert "bedGraph" in b.sql()
+    assert "bedGraph" in bw.sql()
     # We can parse the sql
-    assert b.sql(True)['name'] == 'bedGraph'
+    # assert bw.sql(True)['name'] == 'bedGraph'
 
+    # bb.sql()
+    # BBIReadError: The file was invalid: Invalid autosql: not UTF-8
+
+
+def test_records(bw, bb):
     # (chrom, None, None) => all records on chrom
-    assert len(list(b.records('chr17'))) == 100000
+    assert len(list(bw.records("chr17"))) == 100_000
+    assert len(list(bb.records("chr21"))) == 14_810
+
     # (chrom, start, None) => all records from (start, <chrom_end>)
-    assert len(list(b.records('chr17', 100000))) == 91360
+    assert len(list(bw.records("chr17", 100_000))) == 91_360
+    assert len(list(bb.records("chr21", 10_000_000))) == 14_799
+
     # (chrom, start, end) => all records from (start, end)
-    assert len(list(b.records('chr17', 100000, 110000))) == 1515
+    assert len(list(bw.records("chr17", 100_000, 110_000))) == 1515
+    assert len(list(bb.records("chr21", 10_000_000, 20_000_000))) == 233
+
     # Out of bounds start/end are truncated
-    assert len(list(b.records('chr17', -1000, 100000))) == 8641
-    assert len(list(b.records('chr17', -1000, -500))) == 0
-    assert len(list(b.records('chr17', 0, 84000000))) == 100000
-    assert next(b.records('chr17')) == (59898, 59900, 0.06791999936103821)
+    x = list(bw.records("chr17", 0, 100_000))
+    assert len(x) == 8641
+    assert list(bw.records("chr17", -1000, 100_000)) == x
+    x = list(bb.records("chr21", 0, 10_000_000))
+    assert len(x) == 11
+    assert list(bb.records("chr21", -1000, 10_000_000)) == x
+
+    y = list(bw.records("chr17", 0, bw.chroms("chr17")))
+    assert len(y) == 100_000
+    assert list(bw.records("chr17", 0, bw.chroms("chr17") * 2)) == y
+    assert next(bw.records("chr17")) == (59898, 59900, 0.06791999936103821)
+    y = list(bb.records("chr21", 0, bb.chroms("chr21")))
+    assert len(y) == 14810
+    assert list(bb.records("chr21", 0, bb.chroms("chr21") * 2)) == y
+    assert next(bb.records("chr21")) == (9434178, 9434609)
+
+    # Fully out of bounds ranges return no records
+    assert len(list(bw.records("chr17", -1000, -500))) == 0
+    assert len(list(bw.records("chr17", 83_257_441, 84_000_000))) == 0
+
+    assert len(list(bb.records("chr21", -1000, -500))) == 0
+    assert len(list(bb.records("chr21", 48_129_895, 49_000_000))) == 0
+
     # Unknown chrom  => exception
-    try:
-        b.zoom_records('chr11')
-    except:
-        pass
-    else:
-        assert False
+    assert pytest.raises(KeyError, bw.records, "chr11")
+    assert pytest.raises(KeyError, bb.records, "chr11")
 
+
+def test_zoom_records(bw, bb):
     # (chrom, None, None) => all records on chrom
-    assert len(list(b.zoom_records(10, 'chr17'))) == 13811
+    assert len(list(bw.zoom_records(10, "chr17"))) == 13811
+    assert len(list(bb.zoom_records(3911, "chr21"))) == 1676
+
     # (chrom, start, None) => all records from (start, <chrom_end>)
-    assert len(list(b.zoom_records(10, 'chr17', 100000))) == 10872
+    assert len(list(bw.zoom_records(10, "chr17", 100_000))) == 10872
+    assert len(list(bb.zoom_records(3911, "chr21", 10_000_000))) == 1670
+
     # (chrom, start, end) => all records from (start, end)
-    assert len(list(b.zoom_records(10, 'chr17', 100000, 110000))) == 766
+    assert len(list(bw.zoom_records(10, "chr17", 100_000, 110_000))) == 766
+    assert len(list(bb.zoom_records(3911, "chr21", 10_000_000, 20_000_000))) == 154
+
     # Out of bounds start/end are truncated
-    assert len(list(b.zoom_records(10, 'chr17', -1000, 100000))) == 2940
-    assert len(list(b.zoom_records(10, 'chr17', -1000, -500))) == 0
-    assert len(list(b.zoom_records(10, 'chr17', 0, 84000000))) == 13811
-    assert next(b.zoom_records(10, 'chr17', 0, 100000)) == (59898, 59908, {'total_items': 0, 'bases_covered': 10, 'min_val': 0.06791999936103821, 'max_val': 0.16627000272274017, 'sum': 1.4660000801086426, 'sum_squares': 0.2303919643163681})
-    assert next(b.zoom_records(160, 'chr17', 0, 100000)) == (59898, 60058, {'total_items': 0, 'bases_covered': 160, 'min_val': 0.06791999936103821, 'max_val': 0.8688300251960754, 'sum': 101.3516616821289, 'sum_squares': 80.17473602294922})
+    x = list(bw.zoom_records(10, "chr17", 0, 100_000))
+    assert len(x) == 2940
+    assert list(bw.zoom_records(10, "chr17", -1000, 100_000)) == x
+    x = list(bb.zoom_records(3911, "chr21", 0, 10_000_000))
+    assert len(x) == 6
+    assert list(bb.zoom_records(3911, "chr21", -1000, 10_000_000)) == x
+
+    y = list(bw.zoom_records(10, "chr17", 0, bw.chroms("chr17")))
+    assert len(y) == 13811
+    assert list(bw.zoom_records(10, "chr17", 0, bw.chroms("chr17") * 2)) == y
+    y = list(bb.zoom_records(3911, "chr21", 0, bb.chroms("chr21")))
+    assert len(y) == 1676
+    assert list(bb.zoom_records(3911, "chr21", 0, bb.chroms("chr21") * 2)) == y
+
+    # Fully out of bounds ranges return no records
+    assert len(list(bw.zoom_records(10, "chr17", -1000, -500))) == 0
+    assert len(list(bw.zoom_records(10, "chr17", 83_257_441, 84_000_000))) == 0
+    assert len(list(bb.zoom_records(3911, "chr21", -1000, -500))) == 0
+    assert len(list(bb.zoom_records(3911, "chr21", 48_129_895, 49_000_000))) == 0
+
+    assert next(bw.zoom_records(10, "chr17", 0, 100_000)) == (
+        59898,
+        59908,
+        {
+            "total_items": 0,
+            "bases_covered": 10,
+            "min_val": 0.06791999936103821,
+            "max_val": 0.16627000272274017,
+            "sum": 1.4660000801086426,
+            "sum_squares": 0.2303919643163681,
+        },
+    )
+    assert next(bw.zoom_records(160, "chr17", 0, 100000)) == (
+        59898,
+        60058,
+        {
+            "total_items": 0,
+            "bases_covered": 160,
+            "min_val": 0.06791999936103821,
+            "max_val": 0.8688300251960754,
+            "sum": 101.3516616821289,
+            "sum_squares": 80.17473602294922,
+        },
+    )
+
     # Unknown zoom  => exception
-    try:
-        b.zoom_records(0, 'chr17')
-    except:
-        pass
-    else:
-        assert False
-    # Unknown chrom  => exception
-    try:
-        b.zoom_records(10, 'chr11')
-    except:
-        pass
-    else:
-        assert False
+    assert pytest.raises(KeyError, bw.zoom_records, 0, "chr17")
+    assert pytest.raises(KeyError, bb.zoom_records, 0, "chr21")
 
-    assert len(list(b.values('chr17', 100000, 110000))) == 10000
-    assert len(list(b.values('chr17', 100000, 110000, 10))) == 10
-    assert b.values('chr17', 100000, 110000, 10)[0] == 0.37435242314338685
-    assert b.values('chr17', 100000, 110000, 10, 'max')[0] == 1.1978399753570557
-    assert b.values('chr17', 100000, 110000, 10, 'min')[0] == 0.05403999984264374
-    assert b.values('chr17', 100000, 110000, 10, 'mean',  True)[0] == 0.37885534041374924
-    assert list(b.values('chr17', 59890, 59900, 10, 'mean', True)) == [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.06791999936103821, 0.06791999936103821]
-    assert list(b.values('chr17', 59890, 59900, 10, 'mean', True, -1.0)) == [-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, 0.06791999936103821, 0.06791999936103821]
-    assert math.isnan(b.values('chr17', -10, 10, 20, 'mean', True, 0.0)[0])
-    assert not math.isnan(b.values('chr17', -10, 10, 20, 'mean', True, 0.0)[19])
-    assert b.values('chr17', -10, 10, 20, 'mean', True, 0.0, 0.0)[0] == 0.0
-    arr = np.zeros(20)
-    ret_arr = b.values('chr17', -10, 10, 20, 'mean', True, 0.0, np.nan, arr)
+    # Unknown chrom  => exception
+    assert pytest.raises(KeyError, bw.zoom_records, 10, "chr11")
+    assert pytest.raises(KeyError, bb.zoom_records, 3911, "chr11")
+
+
+def test_values(bw, bb):
+    assert len(bw.values("chr17", 100_000, 110_000)) == 10_000
+    assert len(bb.values("chr21", 10_148_000, 10_158_000)) == 10_000
+
+    assert len(bw.values("chr17", 100000, 110000, 10)) == 10
+    assert len(bb.values("chr21", 10_148_000, 10_158_000, 10)) == 10
+
+    assert bw.values("chr17", 100000, 110000, 10)[0] == 0.37435242314338685
+    assert bb.values("chr21", 10_148_000, 10_158_000, 10)[0] == 0.175
+
+    assert bw.values("chr17", 100000, 110000, 10, "max")[0] == 1.1978399753570557
+    assert bb.values("chr21", 10_148_000, 10_158_000, 10, "max")[0] == 1.0
+
+    assert bw.values("chr17", 100000, 110000, 10, "min")[0] == 0.05403999984264374
+    assert bb.values("chr21", 10_148_000, 10_158_000, 10, "min")[0] == 0.0
+
+    assert (
+        bw.values("chr17", 100000, 110000, 10, "mean", exact=True)[0]
+        == 0.37885534041374924
+    )
+    assert (
+        bb.values("chr21", 10_148_000, 10_158_000, 10, "mean", exact=True)[0]
+        == 0.175
+    )
+
+    assert list(bw.values("chr17", 59890, 59900, 10, "mean", exact=True)) == [
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.06791999936103821,
+        0.06791999936103821,
+    ]
+
+    assert list(
+        bw.values("chr17", 59890, 59900, 10, "mean", exact=True, missing=-1.0)
+    ) == [
+        -1.0,
+        -1.0,
+        -1.0,
+        -1.0,
+        -1.0,
+        -1.0,
+        -1.0,
+        -1.0,
+        0.06791999936103821,
+        0.06791999936103821,
+    ]
+
+    x = bw.values("chr17", -10, 10, 20, "mean", exact=True, missing=0.0)
+    assert math.isnan(x[0])
+    assert not math.isnan(x[19])
+    x = bb.values("chr21", -10, 10, 20, "mean", exact=True, missing=0.0)
+    assert math.isnan(x[0])
+    assert not math.isnan(x[19])
+
+    x = bw.values("chr17", -10, 10, 20, "mean", exact=True, missing=0.0, oob=0.0)
+    assert x[0] == 0.0
+    x = bb.values("chr21", -10, 10, 20, "mean", exact=True, missing=0.0, oob=0.0)
+    assert x[0] == 0.0
+
     # The returned array is the same as the one passed, so both show the same values
+    arr = np.zeros(20)
+    ret_arr = bw.values(
+        "chr17", -10, 10, 20, "mean", exact=True, missing=0.0, oob=np.nan, arr=arr
+    )
     assert math.isnan(arr[0])
     assert arr[19] == 0.0
     assert math.isnan(ret_arr[0])
     assert ret_arr[19] == 0.0
+    assert np.array_equal(arr, ret_arr, equal_nan=True)
 
-    b.close()
-    # Closing means file is not usable
-    try:
-        b.chroms()
-    except:
-        pass
-    else:
-        assert False
-
-    b = pybigtools.open('../bigtools/resources/test/valid.bigWig', 'r')
-    # Files are closed when exiting a context manager
-    with b:
-      pass
-    try:
-        b.chroms()
-    except:
-        pass
-    else:
-        assert False
-
+    ret_arr = bb.values(
+        "chr21", -10, 10, 20, "mean", exact=True, missing=0.0, oob=np.nan, arr=arr
+    )
+    assert math.isnan(arr[0])
+    assert arr[19] == 0.0
+    assert math.isnan(ret_arr[0])
+    assert ret_arr[19] == 0.0
+    assert np.array_equal(arr, ret_arr, equal_nan=True)

--- a/pybigtools/tests/test_api.py
+++ b/pybigtools/tests/test_api.py
@@ -17,6 +17,12 @@ def test_open_close():
     b.close()
     assert pytest.raises(pybigtools.BBIFileClosed, b.chroms)
 
+    # Works with pathlib.Path
+    path = REPO_ROOT / "bigtools/resources/test/valid.bigWig"
+    b = pybigtools.open(path, "r")
+    b.close()
+    assert pytest.raises(pybigtools.BBIFileClosed, b.chroms)
+
     # Files are closed when exiting a context manager
     with pybigtools.open(path, "r") as b:
         pass


### PR DESCRIPTION
- [x] Replaces base `Exception` raises with `ValueError`, `KeyError`, `BBIFileClosed` or `BBIReadError`.
- [x] Unit test refactoring
    * Added fixtures for bigwig and bigbed files
- [x] Numpydoc-style docstrings for methods.
- [x] `b.chroms(chrom)` will raise a `KeyError` instead of returning None if `chrom` does not exist. This seems less surprising to me. The former behavior can be achieved more explicitly with `b.chroms().get(chrom)`.
- [x] Let `open` support `pathlib.Path` objects.
- [x] Make `chrom` and `end` args optional for `b.values()` as in `records` and `zoom_records`. 