### PR TITLE
build: Add .cargo/config for project root `cargo build` on macos

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.'cfg(any(target_os = "macos"))']
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]


### PR DESCRIPTION
This adds the needed flags to build both projects at once from the root dir on macos as described in https://github.com/PyO3/pyo3/issues/1330#issuecomment-748621681

Note that this won't build the Python extension module. That requires `maturin` and should be documented.
