### PR TITLE
Refactor pybigtools API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,9 @@ jobs:
     
       - name: Install pybigtools
         run: |
-          pip install maturin pytest
+          pip install maturin
           cd pybigtools
-          pip install -e .
+          pip install -e .[test]
   
       - name: Install
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "pybigtools"
-version = "0.1.5-dev"
+version = "0.2.0-dev"
 dependencies = [
  "bigtools",
  "futures",

--- a/bigtools/src/bbi/bbiread.rs
+++ b/bigtools/src/bbi/bbiread.rs
@@ -54,6 +54,16 @@ pub struct BBIHeader {
     pub(crate) uncompress_buf_size: u32,
 }
 
+impl BBIHeader {
+    pub fn is_compressed(&self) -> bool {
+        self.uncompress_buf_size > 0
+    }
+
+    pub fn primary_data_size(&self) -> u64 {
+        self.full_index_offset - self.full_data_offset
+    }
+}
+
 /// Information on a chromosome in a bbi file
 #[derive(Clone, Debug)]
 pub struct ChromInfo {

--- a/bigtools/src/bbi/bbiread.rs
+++ b/bigtools/src/bbi/bbiread.rs
@@ -557,10 +557,16 @@ impl<S: SeekableRead> BBIFileRead for S {
     }
 }
 
-pub struct CachedBBIFileRead<S: SeekableRead> {
+pub struct CachedBBIFileRead<S> {
     read: S,
     cir_tree_node_map: HashMap<u64, Either<Vec<CirTreeNodeLeaf>, Vec<CirTreeNodeNonLeaf>>>,
     block_data: HashMap<Block, Vec<u8>>,
+}
+
+impl<S> CachedBBIFileRead<S> {
+    pub fn inner_read(&self) -> &S {
+        &self.read
+    }
 }
 
 impl<S: SeekableRead> CachedBBIFileRead<S> {

--- a/bigtools/src/bbi/bigbedread.rs
+++ b/bigtools/src/bbi/bigbedread.rs
@@ -214,6 +214,11 @@ impl<R: BBIFileRead> BigBedRead<R> {
         })
     }
 
+    /// Gets a reference to the inner `R` type, in order to access any info
+    pub fn inner_read(&self) -> &R {
+        &self.read
+    }
+
     /// Returns the summary data from bigBed
     ///
     /// Note: For version 1 of bigBeds, there is no total summary. In that

--- a/bigtools/src/bbi/bigbedread.rs
+++ b/bigtools/src/bbi/bigbedread.rs
@@ -190,8 +190,11 @@ impl<R: BBIFileRead> BigBedRead<R> {
     }
 
     /// Reads the autosql from this bigBed
-    pub fn autosql(&mut self) -> Result<String, BBIReadError> {
+    pub fn autosql(&mut self) -> Result<Option<String>, BBIReadError> {
         let auto_sql_offset = self.info.header.auto_sql_offset;
+        if auto_sql_offset == 0 {
+            return Ok(None);
+        }
         let reader = self.reader().raw_reader();
         let mut reader = BufReader::new(reader);
         reader.seek(SeekFrom::Start(auto_sql_offset))?;
@@ -200,7 +203,7 @@ impl<R: BBIFileRead> BigBedRead<R> {
         buffer.pop();
         let autosql = String::from_utf8(buffer)
             .map_err(|_| BBIReadError::InvalidFile("Invalid autosql: not UTF-8".to_owned()))?;
-        Ok(autosql)
+        Ok(Some(autosql))
     }
 
     pub fn item_count(&mut self) -> Result<u64, BBIReadError> {

--- a/bigtools/src/bbi/bigbedread.rs
+++ b/bigtools/src/bbi/bigbedread.rs
@@ -329,6 +329,29 @@ impl<R: BBIFileRead> BigBedRead<R> {
         let chrom = self.info.chrom_id(chrom_name)?;
 
         let blocks = search_cir_tree(&self.info, &mut self.read, cir_tree, chrom_name, start, end)?;
+        Ok(ZoomIntervalIter::<
+            std::vec::IntoIter<Block>,
+            BigBedRead<R>,
+            &mut BigBedRead<R>,
+        >::new(self, blocks.into_iter(), chrom, start, end))
+    }
+
+    /// For a given chromosome, start, and end, returns an `Iterator` of the
+    /// intersecting `ZoomRecord`s.
+    pub fn get_zoom_interval_move<'a>(
+        mut self,
+        chrom_name: &str,
+        start: u32,
+        end: u32,
+        reduction_level: u32,
+    ) -> Result<impl Iterator<Item = Result<ZoomRecord, BBIReadError>>, ZoomIntervalError> {
+        let cir_tree = self
+            .zoom_cir_tree(reduction_level)
+            .map_err(|_| ZoomIntervalError::ReductionLevelNotFound)?;
+
+        let chrom = self.info.chrom_id(chrom_name)?;
+
+        let blocks = search_cir_tree(&self.info, &mut self.read, cir_tree, chrom_name, start, end)?;
         Ok(ZoomIntervalIter::new(
             self,
             blocks.into_iter(),

--- a/bigtools/src/bbi/bigwigread.rs
+++ b/bigtools/src/bbi/bigwigread.rs
@@ -348,6 +348,28 @@ where
 
         let blocks = search_cir_tree(&self.info, &mut self.read, cir_tree, chrom_name, start, end)?;
 
+        Ok(ZoomIntervalIter::<
+            std::vec::IntoIter<Block>,
+            BigWigRead<R>,
+            &mut BigWigRead<R>,
+        >::new(self, blocks.into_iter(), chrom, start, end))
+    }
+
+    /// For a given chromosome, start, and end, returns an `Iterator` of the
+    /// intersecting `ZoomRecord`s.
+    pub fn get_zoom_interval_move<'a>(
+        mut self,
+        chrom_name: &str,
+        start: u32,
+        end: u32,
+        reduction_level: u32,
+    ) -> Result<impl Iterator<Item = Result<ZoomRecord, BBIReadError>>, ZoomIntervalError> {
+        let cir_tree = self.zoom_cir_tree(reduction_level)?;
+
+        let chrom = self.info.chrom_id(chrom_name)?;
+
+        let blocks = search_cir_tree(&self.info, &mut self.read, cir_tree, chrom_name, start, end)?;
+
         Ok(ZoomIntervalIter::new(
             self,
             blocks.into_iter(),

--- a/bigtools/src/bbi/bigwigread.rs
+++ b/bigtools/src/bbi/bigwigread.rs
@@ -527,7 +527,7 @@ fn get_block_values<R: BBIFileRead>(
                     end: chrom_end,
                     value,
                 };
-                if value.end >= start && value.start <= end {
+                if value.end > start && value.start < end {
                     value.start = value.start.max(start);
                     value.end = value.end.min(end);
                     values.push(value)
@@ -555,7 +555,7 @@ fn get_block_values<R: BBIFileRead>(
                     end: chrom_end,
                     value,
                 };
-                if value.end >= start && value.start <= end {
+                if value.end > start && value.start < end {
                     value.start = value.start.max(start);
                     value.end = value.end.min(end);
                     values.push(value)
@@ -584,7 +584,7 @@ fn get_block_values<R: BBIFileRead>(
                     end: chrom_end,
                     value,
                 };
-                if value.end >= start && value.start <= end {
+                if value.end > start && value.start < end {
                     value.start = value.start.max(start);
                     value.end = value.end.min(end);
                     values.push(value)

--- a/bigtools/src/utils/cli/bigbedinfo.rs
+++ b/bigtools/src/utils/cli/bigbedinfo.rs
@@ -83,11 +83,17 @@ pub fn bigbedinfo(args: BigBedInfoArgs) -> Result<(), Box<dyn Error>> {
         }
         if args.autosql {
             let autosql = bigbed.autosql()?;
-            if autosql.len() == 0 {
-                println!("as:  n/a");
-            } else {
-                println!("as:");
-                print!("{}", autosql);
+            match autosql {
+                None => {
+                    println!("as:  n/a");
+                }
+                Some(autosql) if autosql.is_empty() => {
+                    println!("as:  n/a");
+                }
+                Some(autosql) => {
+                    println!("as:");
+                    print!("{}", autosql);
+                }
             }
         }
         let summary = bigbed.get_summary()?;

--- a/bigtools/tests/bigbedwrite.rs
+++ b/bigtools/tests/bigbedwrite.rs
@@ -60,7 +60,7 @@ fn bigbedwrite_test() -> Result<(), Box<dyn Error>> {
     assert_eq!(chroms[0].length, 83257441);
 
     assert_eq!(
-        &bwread.autosql().unwrap(),
+        &bwread.autosql().unwrap().unwrap(),
         "table bed\n\"Browser Extensible Data\"\n(\n    string chrom;       \"Reference sequence chromosome or scaffold\"\n    uint   chromStart;  \"Start position in chromosome\"\n    uint   chromEnd;    \"End position in chromosome\"\n   string name;        \"Name of item.\"\n   uint score;          \"Score (0-1000)\"\n)",
     );
 

--- a/pybigtools/Cargo.toml
+++ b/pybigtools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pybigtools"
-version = "0.1.5-dev"
+version = "0.2.0-dev"
 authors = ["Jack <jackh726@gmail.com>"]
 edition = "2021"
 

--- a/pybigtools/pyproject.toml
+++ b/pybigtools/pyproject.toml
@@ -6,8 +6,32 @@ build-backend = "maturin"
 name = "pybigtools"
 description = "Python bindings to the Bigtools Rust library for high-performance BigWig and BigBed I/O"
 license = { text = "MIT" }
+keywords = [
+    "bigwig",
+    "bigbed",
+    "bbi",
+    "bioinformatics",
+    "genomics",
+    "kent",
+    "ucsc",
+    "rust",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Operating System :: OS Independent",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+    "Programming Language :: Rust",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+]
 dependencies = [
     "numpy"
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "smart_open[http]"
 ]
 
 [project.urls]

--- a/pybigtools/src/file_like.rs
+++ b/pybigtools/src/file_like.rs
@@ -8,7 +8,7 @@ use pyo3::{
 /// traits, calling into python io methods.
 #[derive(Clone)]
 pub struct PyFileLikeObject {
-    inner: PyObject,
+    pub(crate) inner: PyObject,
 }
 
 impl PyFileLikeObject {

--- a/pybigtools/src/lib.rs
+++ b/pybigtools/src/lib.rs
@@ -1117,8 +1117,7 @@ impl BBIRead {
     uint   chromStart;   "Start position in chromosome"
     uint   chromEnd;     "End position in chromosome"
     float  value;        "Value for a given interval"
-)\
-            "#;
+)"#;
         let schema = match &mut self.bbi {
             BBIReadRaw::Closed => return Err(BBIFileClosed::new_err("File is closed.")),
             BBIReadRaw::BigWigFile(_) | BBIReadRaw::BigWigFileLike(_) => BEDGRAPH.to_string(),

--- a/pybigtools/src/lib.rs
+++ b/pybigtools/src/lib.rs
@@ -1682,9 +1682,8 @@ impl BBIRead {
         _exc_type: PyObject,
         _exc_value: PyObject,
         _exc_traceback: PyObject,
-    ) -> Py<Self> {
+    ) {
         slf.borrow_mut(py).bbi = BBIReadRaw::Closed;
-        slf
     }
 
     fn __traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError> {

--- a/pybigtools/src/lib.rs
+++ b/pybigtools/src/lib.rs
@@ -1425,7 +1425,7 @@ impl BBIRead {
     /// records : Get the records of a given range on a chromosome.
     /// zoom_records : Get the zoom records of a given range on a chromosome.
     #[pyo3(
-        signature = (chrom, start, end, bins=None, summary="mean".to_string(), exact=false, missing=0.0, oob=f64::NAN, arr=None),
+        signature = (chrom, start=None, end=None, bins=None, summary="mean".to_string(), exact=false, missing=0.0, oob=f64::NAN, arr=None),
         text_signature = r#"(chrom, start, end, bins=None, summary="mean", exact=False, missing=0.0, oob=..., arr=None)"#,
     )]
     fn values(

--- a/pybigtools/src/lib.rs
+++ b/pybigtools/src/lib.rs
@@ -37,8 +37,18 @@ mod file_like;
 
 type ValueTuple = (u32, u32, f32);
 
-create_exception!(pybigtools, BBIFileClosed, exceptions::PyException);
-create_exception!(pybigtools, BBIReadError, exceptions::PyException);
+create_exception!(
+    pybigtools,
+    BBIFileClosed,
+    exceptions::PyException,
+    "BBI File is closed."
+);
+create_exception!(
+    pybigtools,
+    BBIReadError,
+    exceptions::PyException,
+    "Error reading BBI file."
+);
 
 fn start_end(
     bbi: &BBIReadRaw,
@@ -209,7 +219,7 @@ fn intervals_to_array<R: BBIFileRead>(
         Some(bins) => {
             if v.len() != bins {
                 return Err(PyErr::new::<exceptions::PyValueError, _>(format!(
-                    "`arr` does not the expected size (expected `{}`, found `{}`), if passed.",
+                    "`arr` does not have the expected size (expected `{}`, found `{}`), if passed.",
                     bins,
                     v.len(),
                 )));
@@ -303,6 +313,7 @@ fn intervals_to_array<R: BBIFileRead>(
 
     Ok(arr)
 }
+
 fn entries_to_array<R: BBIFileRead>(
     py: Python<'_>,
     b: &mut BigBedReadRaw<R>,
@@ -458,6 +469,7 @@ fn to_array<I: Iterator<Item = Result<Value, _BBIReadError>>>(
     }
     Ok(())
 }
+
 fn to_array_bins<I: Iterator<Item = Result<Value, _BBIReadError>>>(
     start: i32,
     end: i32,
@@ -564,6 +576,7 @@ fn to_array_bins<I: Iterator<Item = Result<Value, _BBIReadError>>>(
     }
     Ok(())
 }
+
 fn to_array_zoom<I: Iterator<Item = Result<ZoomRecord, _BBIReadError>>>(
     start: i32,
     end: i32,
@@ -681,6 +694,7 @@ fn to_array_zoom<I: Iterator<Item = Result<ZoomRecord, _BBIReadError>>>(
     }
     Ok(())
 }
+
 fn to_entry_array<I: Iterator<Item = Result<BedEntry, _BBIReadError>>>(
     start: i32,
     end: i32,
@@ -700,6 +714,7 @@ fn to_entry_array<I: Iterator<Item = Result<BedEntry, _BBIReadError>>>(
     }
     Ok(())
 }
+
 fn to_entry_array_bins<I: Iterator<Item = Result<BedEntry, _BBIReadError>>>(
     start: i32,
     end: i32,

--- a/pybigtools/src/lib.rs
+++ b/pybigtools/src/lib.rs
@@ -3,6 +3,7 @@
 use std::collections::VecDeque;
 use std::fs::File;
 use std::io::{self, BufReader};
+use std::ops::IndexMut;
 use std::path::Path;
 
 use bigtools::bed::autosql::parse::parse_autosql;
@@ -22,8 +23,8 @@ use bigtools::{
 
 use bigtools::utils::reopen::Reopen;
 use file_like::PyFileLikeObject;
-use numpy::ndarray::Array1;
-use numpy::IntoPyArray;
+use numpy::ndarray::ArrayViewMut;
+use numpy::PyArray1;
 use pyo3::exceptions::{self, PyTypeError};
 use pyo3::prelude::*;
 use pyo3::types::{IntoPyDict, PyAny, PyDict, PyFloat, PyInt, PyIterator, PyString, PyTuple};
@@ -153,6 +154,7 @@ impl<T, E: ToPyErr> ConvertResult<T> for Result<T, E> {
 }
 
 fn intervals_to_array<R: BBIFileRead>(
+    py: Python<'_>,
     b: &mut BigWigReadRaw<R>,
     chrom: &str,
     start: Option<i32>,
@@ -178,43 +180,129 @@ fn intervals_to_array<R: BBIFileRead>(
         None
     };
     let (intervals_start, intervals_end) = (start.max(0) as u32, end.min(length) as u32);
-    match (bins, zoom) {
-        (Some(bins), Some(zoom)) => {
-            let iter = b
-                .get_zoom_interval(&chrom, intervals_start, intervals_end, zoom.reduction_level)
-                .convert_err()?;
-            Python::with_gil(|py| {
-                Ok(
-                    to_array_zoom(start, end, iter, summary, bins)
-                        .convert_err()?
-                        .into_pyarray(py)
-                        .to_object(py),
+    match bins {
+        Some(bins) => {
+            let arr = match arr {
+                Some(v) => v,
+                None => PyArray1::from_vec(py, vec![missing; bins]).to_object(py),
+            };
+            let v: &PyArray1<f64> = arr.downcast::<PyArray1<f64>>(py).map_err(|_| {
+                PyErr::new::<exceptions::PyException, _>(
+                    "`arr` option must be a one-dimensional numpy array, if passed.",
                 )
-            })
-        }
-        (Some(bins), None) => {
-            let iter = b.get_interval(&chrom, intervals_start, intervals_end).convert_err()?;
-            Python::with_gil(|py| {
-                Ok(
-                    to_array_bins(start, end, iter, summary, bins)
-                        .convert_err()?
-                        .into_pyarray(py)
-                        .to_object(py),
-                )
-            })
+            })?;
+            {
+                let mut array = v.readwrite();
+
+                match zoom {
+                    Some(zoom) => {
+                        let iter = b
+                            .get_zoom_interval(
+                                &chrom,
+                                intervals_start,
+                                intervals_end,
+                                zoom.reduction_level,
+                            )
+                            .convert_err()?;
+                        to_array_zoom(
+                            start,
+                            end,
+                            iter,
+                            summary,
+                            bins,
+                            missing,
+                            array.as_array_mut(),
+                        )
+                        .convert_err()?;
+                    }
+                    None => {
+                        let iter = b
+                            .get_interval(&chrom, intervals_start, intervals_end)
+                            .convert_err()?;
+                        to_array_bins(
+                            start,
+                            end,
+                            iter,
+                            summary,
+                            bins,
+                            missing,
+                            array.as_array_mut(),
+                        )
+                        .convert_err()?;
+                    }
+                };
+
+                let mut array: ArrayViewMut<'_, f64, numpy::Ix1> = array.as_array_mut();
+
+                let bin_size = (end - start) as f64 / bins as f64;
+                if start < 0 {
+                    let bin_start = 0;
+                    let interval_end = 0 - start;
+                    let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
+                    for i in bin_start..bin_end {
+                        array[i] = oob;
+                    }
+                }
+                if end >= length {
+                    let interval_start = (length as i32) - start;
+                    let interval_end = end - start;
+                    let bin_start = ((interval_start as f64) / bin_size) as usize;
+                    let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
+                    assert_eq!(bin_end, array.len() - 1);
+                    for i in bin_start..bin_end {
+                        array[i] = oob;
+                    }
+                }
+            }
+            Ok(arr)
         }
         _ => {
-            let iter = b.get_interval(&chrom, intervals_start, intervals_end).convert_err()?;
-            Python::with_gil(|py| {
-                Ok(to_array(start, end, iter)
-                    .convert_err()?
-                    .into_pyarray(py)
-                    .to_object(py))
-            })
+            let arr = match arr {
+                Some(v) => v,
+                None => PyArray1::from_vec(py, vec![missing; (end - start) as usize]).to_object(py),
+            };
+            let v: &PyArray1<f64> = arr.downcast::<PyArray1<f64>>(py).map_err(|_| {
+                PyErr::new::<exceptions::PyException, _>(
+                    "`arr` option must be a one-dimensional numpy array, if passed.",
+                )
+            })?;
+
+            {
+                let mut array = v.readwrite();
+
+                let iter = b
+                    .get_interval(&chrom, intervals_start, intervals_end)
+                    .convert_err()?;
+                to_array(start, end, iter, array.as_array_mut()).convert_err()?;
+
+                let mut array: ArrayViewMut<'_, f64, numpy::Ix1> = array.as_array_mut();
+
+                let bin_size = (end - start) as f64;
+                if start < 0 {
+                    let bin_start = 0;
+                    let interval_end = 0 - start;
+                    let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
+                    for i in bin_start..bin_end {
+                        array[i] = oob;
+                    }
+                }
+                if end >= length {
+                    let interval_start = (length as i32) - start;
+                    let interval_end = end - start;
+                    let bin_start = ((interval_start as f64) / bin_size) as usize;
+                    let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
+                    assert_eq!(bin_end, array.len() - 1);
+                    for i in bin_start..bin_end {
+                        array[i] = oob;
+                    }
+                }
+            }
+            Ok(arr)
         }
     }
 }
 fn entries_to_array<R: BBIFileRead>(
+    py: Python<'_>,
     b: &mut BigBedReadRaw<R>,
     chrom: &str,
     start: Option<i32>,
@@ -240,39 +328,108 @@ fn entries_to_array<R: BBIFileRead>(
         None
     };
     let (intervals_start, intervals_end) = (start.max(0) as u32, end.min(length) as u32);
-    match (bins, zoom) {
-        (Some(bins), Some(zoom)) => {
-            let iter = b
-                .get_zoom_interval(&chrom, intervals_start, intervals_end, zoom.reduction_level)
-                .convert_err()?;
-            Python::with_gil(|py| {
-                Ok(
-                    to_entry_array_zoom(start, end, iter, summary, bins)
-                        .convert_err()?
-                        .into_pyarray(py)
-                        .to_object(py),
+    match bins {
+        Some(bins) => {
+            let arr = match arr {
+                Some(v) => v,
+                None => PyArray1::from_vec(py, vec![missing; bins]).to_object(py),
+            };
+            let v: &PyArray1<f64> = arr.downcast::<PyArray1<f64>>(py).map_err(|_| {
+                PyErr::new::<exceptions::PyException, _>(
+                    "`arr` option must be a one-dimensional numpy array, if passed.",
                 )
-            })
-        }
-        (Some(bins), None) => {
-            let iter = b.get_interval(&chrom, intervals_start, intervals_end).convert_err()?;
-            Python::with_gil(|py| {
-                Ok(
-                    to_entry_array_bins(start, end, iter, summary, bins)
-                        .convert_err()?
-                        .into_pyarray(py)
-                        .to_object(py),
-                )
-            })
+            })?;
+            {
+                let mut array = v.readwrite();
+
+                match zoom {
+                    Some(zoom) => {
+                        let iter = b
+                            .get_zoom_interval(
+                                &chrom,
+                                intervals_start,
+                                intervals_end,
+                                zoom.reduction_level,
+                            )
+                            .convert_err()?;
+                        to_entry_array_zoom(start, end, iter, summary, bins, array.as_array_mut())
+                            .convert_err()?;
+                    }
+                    None => {
+                        let iter = b
+                            .get_interval(&chrom, intervals_start, intervals_end)
+                            .convert_err()?;
+                        to_entry_array_bins(start, end, iter, summary, bins, array.as_array_mut())
+                            .convert_err()?;
+                    }
+                };
+
+                let mut array: ArrayViewMut<'_, f64, numpy::Ix1> = array.as_array_mut();
+
+                let bin_size = (end - start) as f64 / bins as f64;
+                if start < 0 {
+                    let bin_start = 0;
+                    let interval_end = 0 - start;
+                    let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
+                    for i in bin_start..bin_end {
+                        array[i] = oob;
+                    }
+                }
+                if end >= length {
+                    let interval_start = (length as i32) - start;
+                    let interval_end = end - start;
+                    let bin_start = ((interval_start as f64) / bin_size) as usize;
+                    let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
+                    assert_eq!(bin_end, array.len() - 1);
+                    for i in bin_start..bin_end {
+                        array[i] = oob;
+                    }
+                }
+            }
+            Ok(arr)
         }
         _ => {
-            let iter = b.get_interval(&chrom, intervals_start, intervals_end).convert_err()?;
-            Python::with_gil(|py| {
-                Ok(to_entry_array(start, end, iter)
-                    .convert_err()?
-                    .into_pyarray(py)
-                    .to_object(py))
-            })
+            let arr = match arr {
+                Some(v) => v,
+                None => PyArray1::from_vec(py, vec![missing; (end - start) as usize]).to_object(py),
+            };
+            let v: &PyArray1<f64> = arr.downcast::<PyArray1<f64>>(py).map_err(|_| {
+                PyErr::new::<exceptions::PyException, _>(
+                    "`arr` option must be a one-dimensional numpy array, if passed.",
+                )
+            })?;
+
+            {
+                let mut array = v.readwrite();
+
+                let iter = b
+                    .get_interval(&chrom, intervals_start, intervals_end)
+                    .convert_err()?;
+                to_entry_array(start, end, iter, array.as_array_mut()).convert_err()?;
+
+                let mut array: ArrayViewMut<'_, f64, numpy::Ix1> = array.as_array_mut();
+
+                let bin_size = (end - start) as f64;
+                if start < 0 {
+                    let bin_start = 0;
+                    let interval_end = 0 - start;
+                    let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
+                    for i in bin_start..bin_end {
+                        array[i] = oob;
+                    }
+                }
+                if end >= length {
+                    let interval_start = (length as i32) - start;
+                    let interval_end = end - start;
+                    let bin_start = ((interval_start as f64) / bin_size) as usize;
+                    let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
+                    assert_eq!(bin_end, array.len() - 1);
+                    for i in bin_start..bin_end {
+                        array[i] = oob;
+                    }
+                }
+            }
+            Ok(arr)
         }
     }
 }
@@ -280,18 +437,18 @@ fn to_array<I: Iterator<Item = Result<Value, BBIReadError>>>(
     start: i32,
     end: i32,
     iter: I,
-) -> Result<Array1<f64>, BBIReadError> {
-    use numpy::ndarray::Array;
-    let mut v = vec![f64::NAN; (end - start) as usize];
+    mut v: ArrayViewMut<'_, f64, numpy::Ix1>,
+) -> Result<(), BBIReadError> {
+    assert_eq!(v.len(), (end - start) as usize);
     for interval in iter {
         let interval = interval?;
         let interval_start = ((interval.start as i32) - start) as usize;
         let interval_end = ((interval.end as i32) - start) as usize;
-        for i in v[interval_start..interval_end].iter_mut() {
-            *i = interval.value as f64;
+        for i in interval_start..interval_end {
+            *v.index_mut(i) += interval.value as f64;
         }
     }
-    Ok(Array::from(v))
+    Ok(())
 }
 fn to_array_bins<I: Iterator<Item = Result<Value, BBIReadError>>>(
     start: i32,
@@ -299,63 +456,12 @@ fn to_array_bins<I: Iterator<Item = Result<Value, BBIReadError>>>(
     iter: I,
     summary: Summary,
     bins: usize,
-) -> Result<Array1<f64>, BBIReadError> {
-    use numpy::ndarray::Array;
-    let mut v = match summary {
-        Summary::Min | Summary::Max => vec![f64::NAN; bins],
-        Summary::Mean => vec![0.0; bins],
-    };
-    let bin_size = (end - start) as f64 / bins as f64;
-    for interval in iter {
-        let interval = interval?;
-        let interval_start = (interval.start as i32) - start;
-        let interval_end = (interval.end as i32) - start;
-        let bin_start = ((interval_start as f64) / bin_size) as usize;
-        let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
-        for bin in bin_start..bin_end {
-            let bin_start = (bin as f64) * bin_size;
-            let bin_end = (bin as f64 + 1.0) * bin_size;
-            let interval_start = (interval_start as f64).max(bin_start);
-            let interval_end = (interval_end as f64).min(bin_end);
-            // Possible overlaps
-            // bin  |-----|    |------|   |-----|
-            // value   |----|   |----|  |----|
-            // overlap ----     ------    ----
-            match summary {
-                Summary::Min => {
-                    v[bin] = v[bin].min(interval.value as f64);
-                }
-                Summary::Max => {
-                    v[bin] = v[bin].max(interval.value as f64);
-                }
-                Summary::Mean => {
-                    let overlap_size = interval_end - interval_start;
-                    v[bin] += (overlap_size as f64) * interval.value as f64;
-                }
-            }
-        }
-    }
-    if let Summary::Mean = summary {
-        let last = v.last().copied().expect("Should be at least one bin.");
-        let last_size = (end - start) as f64 - (bins as f64 - 1.0) * bin_size;
-        v = v.into_iter().map(|v| v / bin_size as f64).collect();
-        // The last bin could be smaller
-        *v.last_mut().expect("Should be at least one bin.") = last / last_size;
-    }
-    Ok(Array::from(v))
-}
-fn to_array_zoom<I: Iterator<Item = Result<ZoomRecord, BBIReadError>>>(
-    start: i32,
-    end: i32,
-    iter: I,
-    summary: Summary,
-    bins: usize,
-) -> Result<Array1<f64>, BBIReadError> {
-    use numpy::ndarray::Array;
-    let mut v = match summary {
-        Summary::Min | Summary::Max => vec![f64::NAN; bins],
-        Summary::Mean => vec![0.0; bins],
-    };
+    missing: f64,
+    mut v: ArrayViewMut<'_, f64, numpy::Ix1>,
+) -> Result<(), BBIReadError> {
+    assert_eq!(v.len(), bins);
+
+    let mut bin_data: VecDeque<(usize, i32, i32, Option<f64>)> = VecDeque::new();
     let bin_size = (end - start) as f64 / bins as f64;
     for interval in iter {
         let interval = interval?;
@@ -363,56 +469,224 @@ fn to_array_zoom<I: Iterator<Item = Result<ZoomRecord, BBIReadError>>>(
         let interval_end = (interval.end as i32).min(end) - start;
         let bin_start = ((interval_start as f64) / bin_size) as usize;
         let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
+
+        while let Some(front) = bin_data.front_mut() {
+            if front.0 < bin_start {
+                let front = bin_data.pop_front().unwrap();
+                let bin = front.0;
+
+                match summary {
+                    Summary::Min => {
+                        v[bin] = front.3.unwrap_or(missing);
+                    }
+                    Summary::Max => {
+                        v[bin] = front.3.unwrap_or(missing);
+                    }
+                    Summary::Mean => {
+                        v[bin] = front.3.map(|v| v / bin_size).unwrap_or(missing);
+                    }
+                }
+            } else {
+                break;
+            }
+        }
+        while let Some(bin) = bin_data
+            .back_mut()
+            .map(|b| ((b.0 + 1) < bin_end).then(|| b.0 + 1))
+            .unwrap_or(Some(bin_start))
+        {
+            let bin_start = ((bin as f64) * bin_size).ceil() as i32;
+            let bin_end = (((bin + 1) as f64) * bin_size).ceil() as i32;
+
+            bin_data.push_back((bin, bin_start, bin_end, None));
+        }
+        for bin in bin_data.iter() {
+            assert!(
+                (bin_start..bin_end).contains(&bin.0),
+                "{} not in {}..{}",
+                bin.0,
+                bin_start,
+                bin_end
+            );
+        }
         for bin in bin_start..bin_end {
-            let bin_start = (bin as f64) * bin_size;
-            let bin_end = (bin as f64 + 1.0) * bin_size;
-            let interval_start = (interval_start as f64).max(bin_start);
-            let interval_end = (interval_end as f64).min(bin_end);
-            // Possible overlaps
-            // bin  |-----|    |------|   |-----|
-            // value   |----|   |----|  |----|
-            // overlap ----     ------    ----
+            assert!(bin_data.iter().find(|b| b.0 == bin).is_some());
+        }
+        for (_bin, bin_start, bin_end, data) in bin_data.iter_mut() {
+            let v = data.get_or_insert_with(|| {
+                match summary {
+                    // min & max are defined for NAN and we are about to set it
+                    // can't use 0.0 because it may be either below or above the real value
+                    Summary::Min | Summary::Max => f64::NAN,
+                    // addition is not defined for NAN
+                    Summary::Mean => 0.0,
+                }
+            });
             match summary {
                 Summary::Min => {
-                    v[bin] = v[bin].min(interval.summary.min_val as f64);
+                    *v = v.min(interval.value as f64);
                 }
                 Summary::Max => {
-                    v[bin] = v[bin].max(interval.summary.max_val as f64);
+                    *v = v.max(interval.value as f64);
                 }
                 Summary::Mean => {
-                    let overlap_size = interval_end - interval_start;
-                    let zoom_mean =
-                        (interval.summary.sum as f64) / (interval.summary.bases_covered as f64);
-                    v[bin] += (overlap_size as f64) * zoom_mean;
+                    let overlap_start = (*bin_start).max(interval_start);
+                    let overlap_end = (*bin_end).min(interval_end);
+                    let overlap_size: i32 = overlap_end - overlap_start;
+                    *v += (overlap_size as f64) * interval.value as f64;
                 }
             }
         }
     }
-    if let Summary::Mean = summary {
-        let last = v.last().copied().expect("Should be at least one bin.");
-        let last_size = (end - start) as f64 - (bins as f64 - 1.0) * bin_size;
-        v = v.into_iter().map(|v| v / bin_size as f64).collect();
-        // The last bin could be smaller
-        *v.last_mut().expect("Should be at least one bin.") = last / last_size;
+    while let Some(front) = bin_data.pop_front() {
+        let bin = front.0;
+
+        match summary {
+            Summary::Min => {
+                v[bin] = front.3.unwrap_or(missing);
+            }
+            Summary::Max => {
+                v[bin] = front.3.unwrap_or(missing);
+            }
+            Summary::Mean => {
+                v[bin] = front.3.map(|v| v / bin_size).unwrap_or(missing);
+            }
+        }
     }
-    Ok(Array::from(v))
+    Ok(())
+}
+fn to_array_zoom<I: Iterator<Item = Result<ZoomRecord, BBIReadError>>>(
+    start: i32,
+    end: i32,
+    iter: I,
+    summary: Summary,
+    bins: usize,
+    missing: f64,
+    mut v: ArrayViewMut<'_, f64, numpy::Ix1>,
+) -> Result<(), BBIReadError> {
+    assert_eq!(v.len(), bins);
+
+    let mut bin_data: VecDeque<(usize, i32, i32, Option<f64>)> = VecDeque::new();
+    let bin_size = (end - start) as f64 / bins as f64;
+    for interval in iter {
+        let interval = interval?;
+        let interval_start = (interval.start as i32).max(start) - start;
+        let interval_end = (interval.end as i32).min(end) - start;
+        let bin_start = ((interval_start as f64) / bin_size) as usize;
+        let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
+
+        while let Some(front) = bin_data.front_mut() {
+            if front.0 < bin_start {
+                let front = bin_data.pop_front().unwrap();
+                let bin = front.0;
+
+                match summary {
+                    Summary::Min => {
+                        v[bin] = front.3.unwrap_or(missing);
+                    }
+                    Summary::Max => {
+                        v[bin] = front.3.unwrap_or(missing);
+                    }
+                    Summary::Mean => {
+                        v[bin] = front.3.map(|v| v / bin_size).unwrap_or(missing);
+                    }
+                }
+            } else {
+                break;
+            }
+        }
+        while let Some(bin) = bin_data
+            .back_mut()
+            .map(|b| ((b.0 + 1) < bin_end).then(|| b.0 + 1))
+            .unwrap_or(Some(bin_start))
+        {
+            let bin_start = ((bin as f64) * bin_size).ceil() as i32;
+            let bin_end = (((bin + 1) as f64) * bin_size).ceil() as i32;
+
+            bin_data.push_back((bin, bin_start, bin_end, None));
+        }
+        for bin in bin_data.iter() {
+            assert!(
+                (bin_start..bin_end).contains(&bin.0),
+                "{} not in {}..{}",
+                bin.0,
+                bin_start,
+                bin_end
+            );
+        }
+        for bin in bin_start..bin_end {
+            assert!(bin_data.iter().find(|b| b.0 == bin).is_some());
+        }
+        for (_bin, bin_start, bin_end, data) in bin_data.iter_mut() {
+            match data.as_mut() {
+                Some(v) => match summary {
+                    Summary::Min => {
+                        *v = v.min(interval.summary.min_val as f64);
+                    }
+                    Summary::Max => {
+                        *v = v.max(interval.summary.max_val as f64);
+                    }
+                    Summary::Mean => {
+                        let overlap_start = (*bin_start).max(interval_start);
+                        let overlap_end = (*bin_end).min(interval_end);
+                        let overlap_size = overlap_end - overlap_start;
+                        let zoom_mean =
+                            (interval.summary.sum as f64) / (interval.summary.bases_covered as f64);
+                        *v += (overlap_size as f64) * zoom_mean;
+                    }
+                },
+                None => match summary {
+                    Summary::Min => {
+                        *data = Some(interval.summary.min_val as f64);
+                    }
+                    Summary::Max => {
+                        *data = Some(interval.summary.max_val as f64);
+                    }
+                    Summary::Mean => {
+                        let overlap_start = (*bin_start).max(interval_start);
+                        let overlap_end = (*bin_end).min(interval_end);
+                        let overlap_size = overlap_end - overlap_start;
+                        let zoom_mean =
+                            (interval.summary.sum as f64) / (interval.summary.bases_covered as f64);
+                        *data = Some((overlap_size as f64) * zoom_mean);
+                    }
+                },
+            }
+        }
+    }
+    while let Some(front) = bin_data.pop_front() {
+        let bin = front.0;
+
+        match summary {
+            Summary::Min => {
+                v[bin] = front.3.unwrap_or(missing);
+            }
+            Summary::Max => {
+                v[bin] = front.3.unwrap_or(missing);
+            }
+            Summary::Mean => {
+                v[bin] = front.3.map(|v| v / bin_size).unwrap_or(missing);
+            }
+        }
+    }
+    Ok(())
 }
 fn to_entry_array<I: Iterator<Item = Result<BedEntry, BBIReadError>>>(
     start: i32,
     end: i32,
     iter: I,
-) -> Result<Array1<f64>, BBIReadError> {
-    use numpy::ndarray::Array;
-    let mut v = vec![0.0; (end - start) as usize];
+    mut v: ArrayViewMut<'_, f64, numpy::Ix1>,
+) -> Result<(), BBIReadError> {
+    assert_eq!(v.len(), (end - start) as usize);
     for interval in iter {
         let interval = interval?;
         let interval_start = ((interval.start as i32) - start) as usize;
         let interval_end = ((interval.end as i32) - start) as usize;
-        for i in v[interval_start..interval_end].iter_mut() {
-            *i += 1.0;
+        for i in interval_start..interval_end {
+            *v.index_mut(i) += 1.0;
         }
     }
-    Ok(Array::from(v))
+    Ok(())
 }
 fn to_entry_array_bins<I: Iterator<Item = Result<BedEntry, BBIReadError>>>(
     start: i32,
@@ -420,10 +694,11 @@ fn to_entry_array_bins<I: Iterator<Item = Result<BedEntry, BBIReadError>>>(
     iter: I,
     summary: Summary,
     bins: usize,
-) -> Result<Array1<f64>, BBIReadError> {
-    use numpy::ndarray::Array;
+    mut v: ArrayViewMut<'_, f64, numpy::Ix1>,
+) -> Result<(), BBIReadError> {
+    assert_eq!(v.len(), bins);
+
     let mut bin_data: VecDeque<(usize, i32, i32, Vec<f64>)> = VecDeque::new();
-    let mut v = vec![0.0; bins];
     let bin_size = (end - start) as f64 / bins as f64;
     for interval in iter {
         let interval = interval?;
@@ -468,7 +743,12 @@ fn to_entry_array_bins<I: Iterator<Item = Result<BedEntry, BBIReadError>>>(
             let bin_start = ((bin as f64) * bin_size).ceil() as i32;
             let bin_end = (((bin + 1) as f64) * bin_size).ceil() as i32;
 
-            bin_data.push_back((bin, bin_start, bin_end, vec![0.0; (bin_end - bin_start) as usize]));
+            bin_data.push_back((
+                bin,
+                bin_start,
+                bin_end,
+                vec![0.0; (bin_end - bin_start) as usize],
+            ));
         }
         for bin in bin_data.iter() {
             assert!(
@@ -486,7 +766,9 @@ fn to_entry_array_bins<I: Iterator<Item = Result<BedEntry, BBIReadError>>>(
             let overlap_start = (*bin_start).max(interval_start);
             let overlap_end = (*bin_end).min(interval_end);
 
-            for i in &mut data[((overlap_start - *bin_start) as usize)..((overlap_end - *bin_start) as usize)] {
+            for i in &mut data
+                [((overlap_start - *bin_start) as usize)..((overlap_end - *bin_start) as usize)]
+            {
                 *i = *i + 1.0;
             }
         }
@@ -514,7 +796,7 @@ fn to_entry_array_bins<I: Iterator<Item = Result<BedEntry, BBIReadError>>>(
             }
         }
     }
-    Ok(Array::from(v))
+    Ok(())
 }
 
 fn to_entry_array_zoom<I: Iterator<Item = Result<ZoomRecord, BBIReadError>>>(
@@ -523,10 +805,11 @@ fn to_entry_array_zoom<I: Iterator<Item = Result<ZoomRecord, BBIReadError>>>(
     iter: I,
     summary: Summary,
     bins: usize,
-) -> Result<Array1<f64>, BBIReadError> {
-    use numpy::ndarray::Array;
+    mut v: ArrayViewMut<'_, f64, numpy::Ix1>,
+) -> Result<(), BBIReadError> {
+    assert_eq!(v.len(), bins);
+
     let mut bin_data: VecDeque<(usize, i32, i32, Vec<f64>)> = VecDeque::new();
-    let mut v = vec![0.0; bins];
     let bin_size = (end - start) as f64 / bins as f64;
     for interval in iter {
         let interval = interval?;
@@ -573,7 +856,12 @@ fn to_entry_array_zoom<I: Iterator<Item = Result<ZoomRecord, BBIReadError>>>(
             let bin_start = ((bin as f64) * bin_size).ceil() as i32;
             let bin_end = (((bin + 1) as f64) * bin_size).ceil() as i32;
 
-            bin_data.push_back((bin, bin_start, bin_end, vec![f64::NAN; (bin_end - bin_start) as usize]));
+            bin_data.push_back((
+                bin,
+                bin_start,
+                bin_end,
+                vec![f64::NAN; (bin_end - bin_start) as usize],
+            ));
         }
         for bin in bin_data.iter() {
             assert!(
@@ -592,7 +880,9 @@ fn to_entry_array_zoom<I: Iterator<Item = Result<ZoomRecord, BBIReadError>>>(
             let overlap_end = (*bin_end).min(interval_end);
 
             let mean = interval.summary.sum / (interval.end - interval.start) as f64;
-            for i in &mut data[((overlap_start - *bin_start) as usize)..((overlap_end - *bin_start) as usize)] {
+            for i in &mut data
+                [((overlap_start - *bin_start) as usize)..((overlap_end - *bin_start) as usize)]
+            {
                 match summary {
                     Summary::Mean => *i += mean,
                     Summary::Min => *i = i.min(interval.summary.min_val),
@@ -627,7 +917,7 @@ fn to_entry_array_zoom<I: Iterator<Item = Result<ZoomRecord, BBIReadError>>>(
             }
         }
     }
-    Ok(Array::from(v))
+    Ok(())
 }
 
 /// This class is the interface for reading a bigWig or bigBed.
@@ -830,6 +1120,7 @@ impl BBIRead {
     #[pyo3(signature = (chrom, start, end, bins=None, summary="mean".to_string(), exact=false, missing=0.0, oob=f64::NAN, arr=None))]
     fn values(
         &mut self,
+        py: Python<'_>,
         chrom: String,
         start: Option<i32>,
         end: Option<i32>,
@@ -852,24 +1143,24 @@ impl BBIRead {
         };
         match &mut self.bbi {
             BBIReadRaw::BigWigFile(b) => intervals_to_array(
-                b, &chrom, start, end, bins, summary, exact, missing, oob, arr,
+                py, b, &chrom, start, end, bins, summary, exact, missing, oob, arr,
             ),
             #[cfg(feature = "remote")]
             BBIReadRaw::BigWigRemote(b) => intervals_to_array(
-                b, &chrom, start, end, bins, summary, exact, missing, oob, arr,
+                py, b, &chrom, start, end, bins, summary, exact, missing, oob, arr,
             ),
             BBIReadRaw::BigWigFileLike(b) => intervals_to_array(
-                b, &chrom, start, end, bins, summary, exact, missing, oob, arr,
+                py, b, &chrom, start, end, bins, summary, exact, missing, oob, arr,
             ),
             BBIReadRaw::BigBedFile(b) => entries_to_array(
-                b, &chrom, start, end, bins, summary, exact, missing, oob, arr,
+                py, b, &chrom, start, end, bins, summary, exact, missing, oob, arr,
             ),
             #[cfg(feature = "remote")]
             BBIReadRaw::BigBedRemote(b) => entries_to_array(
-                b, &chrom, start, end, bins, summary, exact, missing, oob, arr,
+                py, b, &chrom, start, end, bins, summary, exact, missing, oob, arr,
             ),
             BBIReadRaw::BigBedFileLike(b) => entries_to_array(
-                b, &chrom, start, end, bins, summary, exact, missing, oob, arr,
+                py, b, &chrom, start, end, bins, summary, exact, missing, oob, arr,
             ),
         }
     }
@@ -1627,6 +1918,7 @@ fn pybigtools(_py: Python, m: &PyModule) -> PyResult<()> {
 #[cfg(test)]
 mod test {
     use bigtools::BedEntry;
+    use numpy::ndarray::Array;
 
     use crate::to_entry_array_bins;
 
@@ -1637,15 +1929,17 @@ mod test {
             end: 20,
             rest: "".to_string(),
         }];
-        let res = to_entry_array_bins(
+        let mut arr = Array::from(vec![f64::NAN]);
+        to_entry_array_bins(
             10,
             20,
             entries.into_iter().map(|v| Ok(v)),
             crate::Summary::Mean,
             1,
+            arr.view_mut(),
         )
         .unwrap();
-        let res = res.to_vec();
+        let res = arr.to_vec();
         assert_eq!(res, [1.0].into_iter().collect::<Vec<_>>());
 
         let entries = [BedEntry {
@@ -1653,15 +1947,17 @@ mod test {
             end: 20,
             rest: "".to_string(),
         }];
-        let res = to_entry_array_bins(
+        let mut arr = Array::from(vec![f64::NAN, f64::NAN]);
+        to_entry_array_bins(
             10,
             20,
             entries.into_iter().map(|v| Ok(v)),
             crate::Summary::Mean,
             2,
+            arr.view_mut(),
         )
         .unwrap();
-        let res = res.to_vec();
+        let res = arr.to_vec();
         assert_eq!(res, [1.0, 1.0].into_iter().collect::<Vec<_>>());
 
         let entries = [
@@ -1676,35 +1972,41 @@ mod test {
                 rest: "".to_string(),
             },
         ];
-        let res = to_entry_array_bins(
+        let mut arr = Array::from(vec![f64::NAN, f64::NAN]);
+        to_entry_array_bins(
             10,
             20,
             entries.clone().into_iter().map(|v| Ok(v)),
             crate::Summary::Mean,
             2,
+            arr.view_mut(),
         )
         .unwrap();
-        let res = res.to_vec();
+        let res = arr.to_vec();
         assert_eq!(res, [1.0, 2.0].into_iter().collect::<Vec<_>>());
-        let res = to_entry_array_bins(
+        let mut arr = Array::from(vec![f64::NAN]);
+        to_entry_array_bins(
             10,
             20,
             entries.clone().into_iter().map(|v| Ok(v)),
             crate::Summary::Min,
             1,
+            arr.view_mut(),
         )
         .unwrap();
-        let res = res.to_vec();
+        let res = arr.to_vec();
         assert_eq!(res, [1.0].into_iter().collect::<Vec<_>>());
-        let res = to_entry_array_bins(
+        let mut arr = Array::from(vec![f64::NAN]);
+        to_entry_array_bins(
             10,
             20,
             entries.clone().into_iter().map(|v| Ok(v)),
             crate::Summary::Max,
             1,
+            arr.view_mut(),
         )
         .unwrap();
-        let res = res.to_vec();
+        let res = arr.to_vec();
         assert_eq!(res, [2.0].into_iter().collect::<Vec<_>>());
 
         let entries = [
@@ -1724,35 +2026,41 @@ mod test {
                 rest: "".to_string(),
             },
         ];
-        let res = to_entry_array_bins(
+        let mut arr = Array::from(vec![f64::NAN, f64::NAN]);
+        to_entry_array_bins(
             10,
             20,
             entries.clone().into_iter().map(|v| Ok(v)),
             crate::Summary::Mean,
             2,
+            arr.view_mut(),
         )
         .unwrap();
-        let res = res.to_vec();
+        let res = arr.to_vec();
         assert_eq!(res, [1.0, 3.0].into_iter().collect::<Vec<_>>());
-        let res = to_entry_array_bins(
+        let mut arr = Array::from(vec![f64::NAN]);
+        to_entry_array_bins(
             10,
             20,
             entries.clone().into_iter().map(|v| Ok(v)),
             crate::Summary::Min,
             1,
+            arr.view_mut(),
         )
         .unwrap();
-        let res = res.to_vec();
+        let res = arr.to_vec();
         assert_eq!(res, [1.0].into_iter().collect::<Vec<_>>());
-        let res = to_entry_array_bins(
+        let mut arr = Array::from(vec![f64::NAN]);
+        to_entry_array_bins(
             10,
             20,
             entries.clone().into_iter().map(|v| Ok(v)),
             crate::Summary::Max,
             1,
+            arr.view_mut(),
         )
         .unwrap();
-        let res = res.to_vec();
+        let res = arr.to_vec();
         assert_eq!(res, [3.0].into_iter().collect::<Vec<_>>());
     }
 }

--- a/pybigtools/src/lib.rs
+++ b/pybigtools/src/lib.rs
@@ -2131,6 +2131,13 @@ fn open(py: Python, path_url_or_file_like: PyObject, mode: Option<String>) -> Py
         return open_path_or_url(py, string_ref.to_str().unwrap().to_owned(), iswrite);
     }
 
+    // If pathlib.Path, convert to string and try to open
+    let path_class = py.import("pathlib")?.getattr("Path")?;
+    if path_url_or_file_like.as_ref(py).is_instance(path_class)? {
+        let path_str = path_url_or_file_like.as_ref(py).str()?.to_str()?;
+        return open_path_or_url(py, path_str.to_owned(), iswrite);
+    }
+
     if iswrite {
         return Err(PyErr::new::<exceptions::PyValueError, _>(format!(
             "Writing only supports file names",

--- a/pybigtools/src/lib.rs
+++ b/pybigtools/src/lib.rs
@@ -933,7 +933,7 @@ fn to_entry_array_zoom<I: Iterator<Item = Result<ZoomRecord, _BBIReadError>>>(
     Ok(())
 }
 
-/// This class is the interface for reading a bigWig or bigBed.
+/// Interface for reading a BigWig or BigBed file.
 #[pyclass(module = "pybigtools")]
 struct BBIRead {
     bbi: BBIReadRaw,
@@ -981,6 +981,7 @@ impl BBIRead {
         }
     }
 
+    /// Return a dict of information about the BBI file.
     fn info(&mut self, py: Python<'_>) -> PyResult<PyObject> {
         let (info, summary) = match &mut self.bbi {
             BBIReadRaw::Closed => return Err(BBIFileClosed::new_err("File is closed.")),
@@ -1043,6 +1044,8 @@ impl BBIRead {
         Ok(info)
     }
 
+    /// Return a list of sizes in bases of the summary intervals used in each
+    /// of the zoom levels (i.e. reduction levels) of the BBI file.
     fn zooms(&self) -> PyResult<Vec<u32>> {
         let zooms = match &self.bbi {
             BBIReadRaw::Closed => return Err(BBIFileClosed::new_err("File is closed.")),
@@ -1058,20 +1061,38 @@ impl BBIRead {
         Ok(zooms.iter().map(|z| z.reduction_level).collect())
     }
 
-    /// Returns the autosql of this bbi file.
+    /// Return the autoSql schema definition of this BBI file.
     ///
-    /// For bigBeds, this comes directly from the autosql stored in the file.
-    /// For bigWigs, the autosql returned matches that of a bedGraph file.
+    /// For BigBeds, this schema comes directly from the autoSql string stored
+    /// in the file. For BigWigs, the schema generated describes a bedGraph
+    /// file.
     ///
-    /// By default, the autosql is returned as a string. Passing `parse = true`
-    /// returns instead a dictionary of the format:
-    /// ```
-    /// {
-    ///   "name": <declared name>,
-    ///   "comment": <declaration coment>,
-    ///   "fields": [(<field name>, <field type>, <field comment>), ...],
-    /// }
-    /// ```
+    /// Parameters
+    /// ----------
+    /// parse : bool, optional [default: False]
+    ///     If True, return the schema as a dictionary. If False, return the
+    ///     schema as a string. Default is False.
+    ///
+    /// Returns
+    /// -------
+    /// schema : str or dict
+    ///     The autoSql schema of the BBI file. If `parse` is True, the schema
+    ///     is returned as a dictionary of the format:
+    ///
+    ///     ```
+    ///     {
+    ///         "name": <declared name>,
+    ///         "comment": <declaration coment>,
+    ///         "fields": [(<field name>, <field type>, <field comment>), ...],
+    ///     }
+    ///     ```
+    ///
+    /// See Also
+    /// --------
+    /// is_bigwig : Check if the BBI file is a bigWig.
+    /// is_bigbed : Check if the BBI file is a bigBed.
+    /// info : Get information about the BBI file.
+    /// zooms : Get the zoom levels of the BBI file.
     #[pyo3(signature = (parse = false))]
     fn sql(&mut self, py: Python, parse: bool) -> PyResult<PyObject> {
         pub const BEDGRAPH: &str = r#"table bedGraph
@@ -1126,19 +1147,36 @@ impl BBIRead {
         Ok(obj)
     }
 
-    /// Returns the records of a given range on a chromosome.
+    /// Return the records of a given range on a chromosome.
     ///
-    /// The result is an iterator of tuples. For bigWigs, these tuples are in
-    /// the format (start: int, end: int, value: float). For bigBeds, these
+    /// The result is an iterator of tuples. For BigWigs, these tuples are in
+    /// the format (start: int, end: int, value: float). For BigBeds, these
     /// tuples are in the format (start: int, end: int, ...), where the "rest"
     /// fields are split by whitespace.
     ///
-    /// Missing values in bigWigs will results in non-contiguous records.
+    /// Parameters
+    /// ----------
+    /// chrom : str
+    ///     Name of the chromosome.
+    /// start, end : int, optional
+    ///     The range to get values for. If end is not provided, it defaults to
+    ///     the length of the chromosome. If start is not provided, it defaults
+    ///     to the beginning of the chromosome.
     ///
-    /// The chrom argument is the name of the chromosome.  
-    /// The start and end arguments denote the range to get values for.
-    ///  If end is not provided, it defaults to the length of the chromosome.
-    ///  If start is not provided, it defaults to the beginning of the chromosome.
+    /// Returns
+    /// -------
+    /// Iterator[tuple[int, int, float] or tuple[int, int, ...]]
+    ///     An iterator of tuples in the format (start: int, end: int, value:
+    ///     float) for BigWigs, or (start: int, end: int, *rest) for BigBeds.
+    ///
+    /// Notes
+    /// -----
+    /// Missing values in BigWigs will results in non-contiguous records.
+    ///
+    /// See Also
+    /// --------
+    /// zoom_records : Get the zoom records of a given range on a chromosome.
+    /// values : Get the values of a given range on a chromosome.
     fn records(
         &mut self,
         py: Python<'_>,
@@ -1196,15 +1234,52 @@ impl BBIRead {
         }
     }
 
-    /// Returns the zoom records of a given range on a chromosome for a given zoom level.
+    /// Return the zoom records of a given range on a chromosome for a given
+    /// zoom level.
     ///
     /// The result is an iterator of tuples. These tuples are in the format
     /// (start: int, end: int, summary: dict).
     ///
-    /// The chrom argument is the name of the chromosome.  
-    /// The start and end arguments denote the range to get values for.
-    ///  If end is not provided, it defaults to the length of the chromosome.
-    ///  If start is not provided, it defaults to the beginning of the chromosome.
+    /// Parameters
+    /// ----------
+    /// reduction_level : int
+    ///     The zoom level to use, as a resolution in bases. Use the ``zooms``
+    ///     method to get a list of available zoom levels.
+    /// chrom : str
+    ///     Name of the chromosome.
+    /// start, end : int, optional
+    ///     The range to get values for. If end is not provided, it defaults
+    ///     to the length of the chromosome. If start is not provided, it
+    ///     defaults to the beginning of the chromosome.
+    ///
+    /// Returns
+    /// -------
+    /// Iterator[tuple[int, int, dict]]
+    ///     An iterator of tuples in the format (start: int, end: int,
+    ///     summary: dict).
+    ///
+    /// Notes
+    /// -----
+    /// The summary dictionary contains the following keys
+    ///
+    /// - ``total_items``: The number of items in the interval.
+    /// - ``bases_covered``: The number of bases covered by the interval.
+    /// - ``min_val``: The minimum value in the interval.
+    /// - ``max_val``: The maximum value in the interval.
+    /// - ``sum``: The sum of all values in the interval.
+    /// - ``sum_squares``: The sum of the squares of all values in the interval.
+    ///
+    /// For BigWigs, the summary statistics are derived from the unique
+    /// **signal values** associated with each base in the interval.
+    ///
+    /// For BigBeds, the summary statistics instead are derived from the
+    /// **number of BED intervals** overlapping each base in the interval.
+    ///
+    /// See Also
+    /// --------
+    /// zooms : Get a list of available zoom levels.
+    /// records : Get the records of a given range on a chromosome.
+    /// values : Get the values of a given range on a chromosome.
     fn zoom_records(
         &mut self,
         reduction_level: u32,
@@ -1274,21 +1349,66 @@ impl BBIRead {
         }
     }
 
-    /// Returns the values of a given range on a chromosome.
+    /// Return the values of a given range on a chromosome as a numpy array.
     ///
-    /// For bigWigs, the result is an array of length (end - start).
-    /// If a value does not exist in the bigwig for a specific base, it will be nan.
+    /// For BigWigs, the returned values or summary statistics are derived
+    /// from the unique **signal values** associated with each base.
     ///
-    /// For bigBeds, the returned array instead represents a pileup of the count
-    /// of intervals overlapping each base.
+    /// For BigBeds, the returned values or summary statistics instead are
+    /// derived from the **number of BED intervals** overlapping each base.
     ///
-    /// The chrom argument is the name of the chromosome.  
-    /// The start and end arguments denote the range to get values for.  
-    ///  If end is not provided, it defaults to the length of the chromosome.  
-    ///  If start is not provided, it defaults to the beginning of the chromosome.
-    /// The default oob value is `numpy.nan`.
+    /// Parameters
+    /// ----------
+    /// chrom : str
+    ///     Name of the chromosome.  
+    /// start, end : int, optional
+    ///     The range to get values for. If end is not provided, it defaults
+    ///     to the length of the chromosome. If start is not provided, it
+    ///     defaults to the beginning of the chromosome.
+    /// bins : int, optional
+    ///     If provided, the query interval will be divided into equally spaced
+    ///     bins and the values in each bin will be interpolated or summarized.
+    ///     If not provided, the values will be returned for each base.
+    /// summary : Literal["mean", "min", "max"], optional [default: "mean"]
+    ///     The summary statistic to use. Currently supported statistics are
+    ///     ``mean``, ``min``, and ``max``.
+    /// exact : bool, optional [default: False]
+    ///     If True and ``bins`` is specified, return exact summary statistic
+    ///     values instead of interpolating from the optimal zoom level.
+    ///     Default is False.
+    /// missing : float, optional [default: 0.0]
+    ///     Fill-in value for unreported data in valid regions. Default is 0.
+    /// oob : float, optional [default: NaN]
+    ///     Fill-in value for out-of-bounds regions. Default is NaN.
+    /// arr : numpy.ndarray, optional
+    ///     If provided, the values will be written to this array or array
+    ///     view. The array must be of the correct size and type.
     ///
-    /// This returns a numpy array.
+    /// Returns
+    /// -------
+    /// numpy.ndarray
+    ///     The signal values of the bigwig or bigbed in the specified range.
+    ///
+    /// Notes
+    /// -----
+    /// A BigWig file encodes a step function, and the value at
+    /// a base is given by the signal value of the unique interval that
+    /// contains that base.
+    ///
+    /// A BigBed file encodes a collection of (possibly overlapping) intervals
+    /// which may or may not be associated with quantitative scores. The
+    /// "value" at given base used here summarizes the number of intervals
+    /// overlapping that base, not any particular score.
+    ///
+    /// If a number of bins is requested and ``exact`` is False, the summarized
+    /// data is interpolated from the closest available zoom level. If you
+    /// need accurate summary data and are okay with small trade-off in speed,
+    /// set ``exact`` to True.
+    ///
+    /// See Also
+    /// --------
+    /// records : Get the records of a given range on a chromosome.
+    /// zoom_records : Get the zoom records of a given range on a chromosome.
     #[pyo3(
         signature = (chrom, start, end, bins=None, summary="mean".to_string(), exact=false, missing=0.0, oob=f64::NAN, arr=None),
         text_signature = r#"(chrom, start, end, bins=None, summary="mean", exact=False, missing=0.0, oob=..., arr=None)"#,
@@ -1341,12 +1461,19 @@ impl BBIRead {
         }
     }
 
-    /// Returns the chromosomes in a bigwig, and their lengths.  
+    /// Return the names of chromosomes in a BBI file and their lengths.  
     ///
-    /// The chroms argument can be either String or None.  
-    ///  If it is None, then all chroms will be returned.  
-    ///  If it is a String, then the length of that chromosome will be returned.  
-    ///  If the chromosome doesn't exist, nothing will be returned.  
+    /// Parameters
+    /// ----------
+    /// chrom : str or None
+    ///     The name of the chromosome to get the length of. If None, then a
+    ///     dictionary of all chromosome sizes will be returned. If the
+    ///     chromosome doesn't exist, returns None.
+    ///
+    /// Returns
+    /// -------
+    /// int or Dict[str, int] or None:
+    ///     Chromosome length or a dictionary of chromosome lengths.
     fn chroms(&mut self, py: Python, chrom: Option<String>) -> PyResult<Option<PyObject>> {
         fn get_chrom_obj<B: bigtools::BBIRead>(
             b: &B,
@@ -1383,25 +1510,38 @@ impl BBIRead {
     }
 
     /// Gets the average values from a bigWig over the entries of a bed file.
-    /// Raises an exception if the current file is a bigBed.
     ///
-    /// Parameters:
-    ///     bed (str): The path to the bed.
-    ///     names (None, bool, or int):  
-    ///         If `None`, then each return value will be a single `float`,
-    ///             the average value over an interval in the bed file.  
-    ///         If `True`, then each return value will be a tuple of the value of column 4
-    ///             and the average value over the interval with that name in the bed file.  
-    ///         If `False`, then each return value will be a tuple of the interval in the format
-    ///             `{chrom}:{start}-{end}` and the average value over that interval.  
-    ///         If `0`, then each return value will match as if `False` was passed.  
-    ///         If a `1+`, then each return value will be a tuple of the value of column of this
-    ///             parameter (1-based) and the average value over the interval.  
+    /// Parameters
+    /// ----------
+    /// bed : str
+    ///     The path to the bed.
+    /// names : bool or int, optional
+    ///     If ``None``, then each return value will be a single float, the
+    ///     average value over an interval in the bed file.  
+    ///     
+    ///     If ``True``, then each return value will be a tuple of the value of
+    ///     column 4 and the average value over the interval with that name in the
+    ///     bed file.  
+    ///     
+    ///     If ``False``, then each return value will be a tuple of the interval
+    ///     in the format ``{chrom}:{start}-{end}`` and the average value over
+    ///     that interval.  
+    ///     
+    ///     If ``0``, then each return value will match as if ``False`` was passed.
+    ///   
+    ///     If a ``1+``, then each return value will be a tuple of the value of
+    ///     column of this parameter (1-based) and the average value over the
+    ///     interval.  
     ///
-    /// Returns:
-    ///     This returns a generator of values. (Therefore, to save to a list, do `list(bigWigAverageOverBed(...))`)  
-    ///     If no name is specified (see the `names` parameter above), then returns a generator of `float`s.  
-    ///     If a name column is specified (see above), then returns a generator of tuples `({name}, {average})`
+    /// Returns
+    /// -------
+    /// Generator of float or tuple.
+    ///
+    /// Notes
+    /// -----
+    /// If no ``name`` field is specified, returns a generator of floats.  
+    /// If a ``name`` column is specified, returns a generator of tuples
+    /// ``({name}, {average})``.
     fn average_over_bed(
         &mut self,
         py: Python,
@@ -1530,9 +1670,10 @@ impl ZoomIntervalIterator {
     }
 }
 
-/// This class is an iterator for `Values` from a bigWig.  
-/// It returns only values that exist in the bigWig, skipping
-/// any missing intervals.
+/// An iterator for intervals in a bigWig.  
+///
+/// It returns only values that exist in the bigWig, skipping any missing
+/// intervals.
 #[pyclass(module = "pybigtools")]
 struct BigWigIntervalIterator {
     iter: Box<dyn Iterator<Item = Result<Value, _BBIReadError>> + Send>,
@@ -1553,7 +1694,7 @@ impl BigWigIntervalIterator {
     }
 }
 
-/// This class is an interator for the entries in a bigBed file.
+/// An iterator for the entries in a bigBed.
 #[pyclass(module = "pybigtools")]
 struct BigBedEntriesIterator {
     iter: Box<dyn Iterator<Item = Result<BedEntry, _BBIReadError>> + Send>,
@@ -1581,7 +1722,7 @@ impl BigBedEntriesIterator {
     }
 }
 
-/// This class is the interface for writing a bigWig.
+/// Interface for writing to a BigWig file.
 #[pyclass(module = "pybigtools")]
 struct BigWigWrite {
     bigwig: Option<BigWigWriteRaw>,
@@ -1589,11 +1730,24 @@ struct BigWigWrite {
 
 #[pymethods]
 impl BigWigWrite {
-    /// Writes the values passsed to the bigwig file.
-    /// The underlying file will be closed automatically when the function completes (and no other operations will be able to be performed).  
+    /// Write values to the BigWig file.
     ///
-    /// The chroms argument should be a dictionary with keys as chromosome names and values as their length.  
-    /// The vals argument should be an iterable with values (String, int, int, float) that represents each value to write in the format (chromosome, start, end, value).  
+    /// The underlying file will be closed automatically when the function
+    /// completes (and no other operations will be able to be performed).
+    ///
+    /// Parameters
+    /// ----------
+    /// chroms : Dict[str, int]
+    ///     A dictionary with keys as chromosome names and values as their
+    ///     length.
+    /// vals : Iterable[tuple[str, int, int, float]]
+    ///     An iterable with values that represents each value to write in the
+    ///     format (chromosome, start, end, value).
+    ///
+    /// Notes
+    /// -----
+    /// The underlying file will be closed automatically when the function
+    /// completes, and no other operations will be able to be performed.  
     fn write(&mut self, py: Python, chroms: &PyDict, vals: Py<PyAny>) -> PyResult<()> {
         let runtime = runtime::Builder::new_multi_thread()
             .worker_threads(
@@ -1709,18 +1863,17 @@ impl BigWigWrite {
         })
     }
 
-    /// close()
-    /// --
+    /// Close the file.
     ///
-    /// Manually closed the file.
-    /// No other operations will be allowed after it is closed. This is done automatically after write is performed.
+    /// No other operations will be allowed after it is closed. This is done
+    /// automatically after write is performed.
     fn close(&mut self) -> PyResult<()> {
         self.bigwig.take();
         Ok(())
     }
 }
 
-/// This class is the interface for writing to a bigBed.
+/// Interface for writing to a BigBed file.
 #[pyclass(module = "pybigtools")]
 struct BigBedWrite {
     bigbed: Option<BigBedWriteRaw>,
@@ -1728,10 +1881,25 @@ struct BigBedWrite {
 
 #[pymethods]
 impl BigBedWrite {
-    /// Writes the values passsed to the bigwig file. The underlying file will be closed automatically when the function completes (and no other operations will be able to be performed).  
-    /// The chroms argument should be a dictionary with keys as chromosome names and values as their length.  
-    /// The vals argument should be an iterable with values (String, int, int, String) that represents each value to write in the format (chromosome, start, end, rest)  
-    ///   The rest String should consist of tab-delimited fields.  
+    /// Write values to the BigBed file.
+    ///
+    /// The underlying file will be closed automatically when the function
+    /// completes (and no other operations will be able to be performed).
+    ///
+    /// Parameters
+    /// ----------
+    /// chroms : Dict[str, int]
+    ///     A dictionary with keys as chromosome names and values as their
+    ///     length.
+    /// vals : Iterable[tuple[str, int, int, str]]
+    ///     An iterable with values that represents each value to write in the
+    ///     format (chromosome, start, end, rest). The ``rest`` string should
+    ///     consist of tab-delimited fields.  
+    ///
+    /// Notes
+    /// -----
+    /// The underlying file will be closed automatically when the function
+    /// completes, and no other operations will be able to be performed.
     fn write(&mut self, py: Python, chroms: &PyDict, vals: Py<PyAny>) -> PyResult<()> {
         let runtime = runtime::Builder::new_multi_thread()
             .worker_threads(
@@ -1850,7 +2018,10 @@ impl BigBedWrite {
         })
     }
 
-    /// Manually closed the file. No other operations will be allowed after it is closed. This is done automatically after write is performed.
+    /// Close the file.
+    ///
+    /// No other operations will be allowed after it is closed. This is done
+    /// automatically after write is performed.
     fn close(&mut self) -> PyResult<()> {
         self.bigbed.take();
         Ok(())
@@ -1908,26 +2079,29 @@ impl BigWigAverageOverBedEntriesIterator {
     }
 }
 
-/// This is the entrypoint for working with bigWigs or bigBeds.
+/// Open a BigWig or BigBed file for reading or writing.
 ///
-/// The first argument can take one of three values:
-/// 1) A path to a file as a string
-/// 2) An http url for a remote file as a string
-/// 3) A file-like object with a `read` and `seek` method
+/// Parameters
+/// ----------
+/// path_url_or_file_like : str or file-like object
+///     The path to a file or an http url for a remote file as a string, or
+///     a Python file-like object with ``read`` and ``seek`` methods.
+/// mode : Literal["r", "w"], optional [default: "r"]
+///     The mode to open the file in. If not provided, it will default to read.
+///     "r" will open a bigWig/bigBed for reading but will not allow writing.
+///     "w" will open a bigWig/bigBed for writing but will not allow reading.
 ///
-/// When writing, only a file path can be used.
+/// Returns
+/// -------
+/// BigWigWrite or BigBedWrite or BBIRead
+///     The object for reading or writing the BigWig or BigBed file.
 ///
-/// The mode is either "w", "r", or None. "r" or None will open a
-/// bigWig or bigBed for reading (but will not allow writing).
-/// "w" Will open a bigWig/bigBed for writing (but will not allow reading).
+/// Notes
+/// -----
+/// For writing, only a file path is currently accepted.
 ///
-/// If passing a file-like object, simultaneous reading of different intervals
+/// If passing a file-like object, concurrent reading of different intervals
 /// is not supported and may result in incorrect behavior.
-///
-/// This returns one of the following:  
-/// - `BigWigWrite`
-/// - `BigBedWrite`
-/// - `BBIRead`
 #[pyfunction]
 fn open(py: Python, path_url_or_file_like: PyObject, mode: Option<String>) -> PyResult<PyObject> {
     let iswrite = match &mode {
@@ -2105,21 +2279,21 @@ fn open_path_or_url(
     Ok(res)
 }
 
-/// The base module for opening a bigWig or bigBed. The only defined function is `open`.
+/// Read and write Big Binary Indexed (BBI) file types: BigWig and BigBed.
 #[pymodule]
 fn pybigtools(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
-    m.add("BBIFileClosed", m.py().get_type::<BBIFileClosed>())?;
-    m.add("BBIReadError", m.py().get_type::<BBIReadError>())?;
 
     m.add_wrapped(wrap_pyfunction!(open))?;
 
+    m.add_class::<BBIRead>()?;
     m.add_class::<BigWigWrite>()?;
     m.add_class::<BigBedWrite>()?;
-    m.add_class::<BBIRead>()?;
-
     m.add_class::<BigWigIntervalIterator>()?;
     m.add_class::<BigBedEntriesIterator>()?;
+
+    m.add("BBIFileClosed", m.py().get_type::<BBIFileClosed>())?;
+    m.add("BBIReadError", m.py().get_type::<BBIReadError>())?;
 
     Ok(())
 }

--- a/pybigtools/src/lib.rs
+++ b/pybigtools/src/lib.rs
@@ -516,8 +516,8 @@ fn to_array_bins<I: Iterator<Item = Result<Value, _BBIReadError>>>(
             .map(|b| ((b.0 + 1) < bin_end).then(|| b.0 + 1))
             .unwrap_or(Some(bin_start))
         {
-            let bin_start = ((bin as f64) * bin_size).ceil() as i32;
-            let bin_end = (((bin + 1) as f64) * bin_size).ceil() as i32;
+            let bin_start = ((bin as f64) * bin_size) as i32;
+            let bin_end = (((bin + 1) as f64) * bin_size) as i32;
 
             bin_data.push_back((bin, bin_start, bin_end, None));
         }
@@ -625,8 +625,8 @@ fn to_array_zoom<I: Iterator<Item = Result<ZoomRecord, _BBIReadError>>>(
             .map(|b| ((b.0 + 1) < bin_end).then(|| b.0 + 1))
             .unwrap_or(Some(bin_start))
         {
-            let bin_start = ((bin as f64) * bin_size).ceil() as i32;
-            let bin_end = (((bin + 1) as f64) * bin_size).ceil() as i32;
+            let bin_start = ((bin as f64) * bin_size) as i32;
+            let bin_end = (((bin + 1) as f64) * bin_size) as i32;
 
             bin_data.push_back((bin, bin_start, bin_end, None));
         }
@@ -779,8 +779,8 @@ fn to_entry_array_bins<I: Iterator<Item = Result<BedEntry, _BBIReadError>>>(
             .map(|b| ((b.0 + 1) < bin_end).then(|| b.0 + 1))
             .unwrap_or(Some(bin_start))
         {
-            let bin_start = ((bin as f64) * bin_size).ceil() as i32;
-            let bin_end = (((bin + 1) as f64) * bin_size).ceil() as i32;
+            let bin_start = ((bin as f64) * bin_size) as i32;
+            let bin_end = (((bin + 1) as f64) * bin_size) as i32;
 
             bin_data.push_back((
                 bin,
@@ -911,8 +911,8 @@ fn to_entry_array_zoom<I: Iterator<Item = Result<ZoomRecord, _BBIReadError>>>(
             .map(|b| ((b.0 + 1) < bin_end).then(|| b.0 + 1))
             .unwrap_or(Some(bin_start))
         {
-            let bin_start = ((bin as f64) * bin_size).ceil() as i32;
-            let bin_end = (((bin + 1) as f64) * bin_size).ceil() as i32;
+            let bin_start = ((bin as f64) * bin_size) as i32;
+            let bin_end = (((bin + 1) as f64) * bin_size) as i32;
 
             bin_data.push_back((
                 bin,

--- a/pybigtools/src/lib.rs
+++ b/pybigtools/src/lib.rs
@@ -766,7 +766,8 @@ fn to_entry_array_bins<I: Iterator<Item = Result<BedEntry, _BBIReadError>>>(
                             .iter()
                             .any(|v| *v > 0)
                             .then(|| front.3.into_iter().sum::<i32>() as f64)
-                            .map(|c| front.4.into_iter().sum::<f64>() / c)
+                            // Map nan to 0 so the sum is non-nan
+                            .map(|c| front.4.into_iter().map(|c| c.max(0.0)).sum::<f64>() / c)
                             .unwrap_or(missing);
                     }
                 }
@@ -841,7 +842,8 @@ fn to_entry_array_bins<I: Iterator<Item = Result<BedEntry, _BBIReadError>>>(
                     .iter()
                     .any(|v| *v > 0)
                     .then(|| front.3.into_iter().sum::<i32>() as f64)
-                    .map(|c| front.4.into_iter().sum::<f64>() / c)
+                    // Map nan to 0 so the sum is non-nan
+                    .map(|c| front.4.into_iter().map(|c| c.max(0.0)).sum::<f64>() / c)
                     .unwrap_or(missing);
             }
         }
@@ -898,7 +900,8 @@ fn to_entry_array_zoom<I: Iterator<Item = Result<ZoomRecord, _BBIReadError>>>(
                             .iter()
                             .any(|v| *v > 0)
                             .then(|| front.3.into_iter().sum::<i32>() as f64)
-                            .map(|c| front.4.into_iter().sum::<f64>() / c)
+                            // Map nan to 0 so the sum is non-nan
+                            .map(|c| front.4.into_iter().map(|c| c.max(0.0)).sum::<f64>() / c)
                             .unwrap_or(missing);
                     }
                 }
@@ -938,7 +941,7 @@ fn to_entry_array_zoom<I: Iterator<Item = Result<ZoomRecord, _BBIReadError>>>(
             let overlap_start = (*bin_start).max(interval_start);
             let overlap_end = (*bin_end).min(interval_end);
 
-            let mean = interval.summary.sum / (interval.end - interval.start) as f64;
+            let mean = interval.summary.sum / (interval.summary.bases_covered) as f64;
             let range =
                 ((overlap_start - *bin_start) as usize)..((overlap_end - *bin_start) as usize);
             for i in &mut data[range.clone()] {
@@ -979,7 +982,8 @@ fn to_entry_array_zoom<I: Iterator<Item = Result<ZoomRecord, _BBIReadError>>>(
                     .iter()
                     .any(|v| *v > 0)
                     .then(|| front.3.into_iter().sum::<i32>() as f64)
-                    .map(|c| front.4.into_iter().sum::<f64>() / c)
+                    // Map nan to 0 so the sum is non-nan
+                    .map(|c| front.4.into_iter().map(|c| c.max(0.0)).sum::<f64>() / c)
                     .unwrap_or(missing);
             }
         }

--- a/pybigtools/src/lib.rs
+++ b/pybigtools/src/lib.rs
@@ -26,9 +26,9 @@ use file_like::PyFileLikeObject;
 use numpy::ndarray::ArrayViewMut;
 use numpy::PyArray1;
 use pyo3::exceptions::{self, PyTypeError};
-use pyo3::prelude::*;
 use pyo3::types::{IntoPyDict, PyAny, PyDict, PyFloat, PyInt, PyIterator, PyString, PyTuple};
-use pyo3::wrap_pyfunction;
+use pyo3::{create_exception, wrap_pyfunction};
+use pyo3::{prelude::*, PyTraverseError, PyVisit};
 
 use tokio::runtime;
 use url::Url;
@@ -37,13 +37,16 @@ mod file_like;
 
 type ValueTuple = (u32, u32, f32);
 
+create_exception!(pybigtools, BBIFileClosed, exceptions::PyException);
+
 fn start_end(
     bbi: &BBIReadRaw,
     chrom_name: &str,
-    start: Option<u32>,
-    end: Option<u32>,
+    start: Option<i32>,
+    end: Option<i32>,
 ) -> PyResult<(u32, u32)> {
     let chroms = match &bbi {
+        BBIReadRaw::Closed => return Err(BBIFileClosed::new_err("File is closed.")),
         BBIReadRaw::BigWigFile(b) => b.chroms(),
         #[cfg(feature = "remote")]
         BBIReadRaw::BigWigRemote(b) => b.chroms(),
@@ -63,7 +66,10 @@ fn start_end(
         }
         Some(c) => c.length,
     };
-    return Ok((start.unwrap_or(0), end.unwrap_or(length)));
+    return Ok((
+        start.map(|v| v.max(0) as u32).unwrap_or(0),
+        end.map(|v| (v.max(0) as u32).min(length)).unwrap_or(length),
+    ));
 }
 
 fn bigwig_start_end_length<R>(
@@ -112,6 +118,7 @@ impl Reopen for PyFileLikeObject {
 }
 
 enum BBIReadRaw {
+    Closed,
     BigWigFile(BigWigReadRaw<CachedBBIFileRead<ReopenableFile>>),
     #[cfg(feature = "remote")]
     BigWigRemote(BigWigReadRaw<CachedBBIFileRead<RemoteFile>>),
@@ -968,6 +975,7 @@ impl BBIRead {
 
     fn info(&mut self, py: Python<'_>) -> PyResult<PyObject> {
         let (info, summary) = match &mut self.bbi {
+            BBIReadRaw::Closed => return Err(BBIFileClosed::new_err("File is closed.")),
             BBIReadRaw::BigWigFile(b) => {
                 let summary = b.get_summary()?;
                 (b.info(), summary)
@@ -1025,8 +1033,9 @@ impl BBIRead {
         Ok(info)
     }
 
-    fn zooms(&self) -> Vec<u32> {
+    fn zooms(&self) -> PyResult<Vec<u32>> {
         let zooms = match &self.bbi {
+            BBIReadRaw::Closed => return Err(BBIFileClosed::new_err("File is closed.")),
             BBIReadRaw::BigWigFile(b) => &b.info().zoom_headers,
             BBIReadRaw::BigWigRemote(b) => &b.info().zoom_headers,
             BBIReadRaw::BigWigFileLike(b) => &b.info().zoom_headers,
@@ -1034,7 +1043,7 @@ impl BBIRead {
             BBIReadRaw::BigBedRemote(b) => &b.info().zoom_headers,
             BBIReadRaw::BigBedFileLike(b) => &b.info().zoom_headers,
         };
-        zooms.iter().map(|z| z.reduction_level).collect()
+        Ok(zooms.iter().map(|z| z.reduction_level).collect())
     }
 
     /// Returns the autosql of this bbi file.
@@ -1051,19 +1060,19 @@ impl BBIRead {
     ///   "fields": [(<field name>, <field type>, <field comment>), ...],
     /// }
     /// ```
-    fn sql(&mut self, py: Python, parse: Option<bool>) -> PyResult<PyObject> {
-        let parse = parse.unwrap_or(false);
-        pub const BEDGRAPH: &str = r#"
-            table bedGraph
-            "bedGraph file"
-            (
-                string chrom;        "Reference sequence chromosome or scaffold"
-                uint   chromStart;   "Start position in chromosome"
-                uint   chromEnd;     "End position in chromosome"
-                float  value;        "Value for a given interval"
-            )
+    #[pyo3(signature = (parse = false))]
+    fn sql(&mut self, py: Python, parse: bool) -> PyResult<PyObject> {
+        pub const BEDGRAPH: &str = r#"table bedGraph
+"bedGraph file"
+(
+    string chrom;        "Reference sequence chromosome or scaffold"
+    uint   chromStart;   "Start position in chromosome"
+    uint   chromEnd;     "End position in chromosome"
+    float  value;        "Value for a given interval"
+)\
             "#;
         let schema = match &mut self.bbi {
+            BBIReadRaw::Closed => return Err(BBIFileClosed::new_err("File is closed.")),
             BBIReadRaw::BigWigFile(_)
             | BBIReadRaw::BigWigRemote(_)
             | BBIReadRaw::BigWigFileLike(_) => BEDGRAPH.to_string(),
@@ -1122,11 +1131,12 @@ impl BBIRead {
         &mut self,
         py: Python<'_>,
         chrom: String,
-        start: Option<u32>,
-        end: Option<u32>,
+        start: Option<i32>,
+        end: Option<i32>,
     ) -> PyResult<PyObject> {
         let (start, end) = start_end(&self.bbi, &chrom, start, end)?;
         match &self.bbi {
+            BBIReadRaw::Closed => return Err(BBIFileClosed::new_err("File is closed.")),
             BBIReadRaw::BigWigFile(b) => {
                 let b = b.reopen()?;
                 Ok(BigWigIntervalIterator {
@@ -1187,11 +1197,12 @@ impl BBIRead {
         &mut self,
         reduction_level: u32,
         chrom: String,
-        start: Option<u32>,
-        end: Option<u32>,
+        start: Option<i32>,
+        end: Option<i32>,
     ) -> PyResult<ZoomIntervalIterator> {
         let (start, end) = start_end(&self.bbi, &chrom, start, end)?;
         match &self.bbi {
+            BBIReadRaw::Closed => return Err(BBIFileClosed::new_err("File is closed.")),
             BBIReadRaw::BigWigFile(b) => {
                 let b = b.reopen()?;
                 let iter = b
@@ -1262,10 +1273,14 @@ impl BBIRead {
     /// The chrom argument is the name of the chromosome.  
     /// The start and end arguments denote the range to get values for.  
     ///  If end is not provided, it defaults to the length of the chromosome.  
-    ///  If start is not provided, it defaults to the beginning of the chromosome.  
+    ///  If start is not provided, it defaults to the beginning of the chromosome.
+    /// The default oob value is `numpy.nan`.
     ///
     /// This returns a numpy array.
-    #[pyo3(signature = (chrom, start, end, bins=None, summary="mean".to_string(), exact=false, missing=0.0, oob=f64::NAN, arr=None))]
+    #[pyo3(
+        signature = (chrom, start, end, bins=None, summary="mean".to_string(), exact=false, missing=0.0, oob=f64::NAN, arr=None),
+        text_signature = r#"(chrom, start, end, bins=None, summary="mean", exact=False, missing=0.0, oob=..., arr=None)"#,
+    )]
     fn values(
         &mut self,
         py: Python<'_>,
@@ -1290,6 +1305,7 @@ impl BBIRead {
             }
         };
         match &mut self.bbi {
+            BBIReadRaw::Closed => return Err(BBIFileClosed::new_err("File is closed.")),
             BBIReadRaw::BigWigFile(b) => intervals_to_array(
                 py, b, &chrom, start, end, bins, summary, exact, missing, oob, arr,
             ),
@@ -1319,7 +1335,7 @@ impl BBIRead {
     ///  If it is None, then all chroms will be returned.  
     ///  If it is a String, then the length of that chromosome will be returned.  
     ///  If the chromosome doesn't exist, nothing will be returned.  
-    fn chroms(&mut self, py: Python, chrom: Option<String>) -> Option<PyObject> {
+    fn chroms(&mut self, py: Python, chrom: Option<String>) -> PyResult<Option<PyObject>> {
         fn get_chrom_obj<B: bigtools::BBIRead>(
             b: &B,
             py: Python,
@@ -1341,7 +1357,8 @@ impl BBIRead {
                 ),
             }
         }
-        match &self.bbi {
+        Ok(match &self.bbi {
+            BBIReadRaw::Closed => return Err(BBIFileClosed::new_err("File is closed.")),
             BBIReadRaw::BigWigFile(b) => get_chrom_obj(b, py, chrom),
             #[cfg(feature = "remote")]
             BBIReadRaw::BigWigRemote(b) => get_chrom_obj(b, py, chrom),
@@ -1350,7 +1367,41 @@ impl BBIRead {
             #[cfg(feature = "remote")]
             BBIReadRaw::BigBedRemote(b) => get_chrom_obj(b, py, chrom),
             BBIReadRaw::BigBedFileLike(b) => get_chrom_obj(b, py, chrom),
+        })
+    }
+
+    fn close(&mut self) {
+        self.bbi = BBIReadRaw::Closed;
+    }
+
+    fn __enter__(slf: Py<Self>) -> Py<Self> {
+        slf
+    }
+
+    fn __exit__(
+        slf: Py<Self>,
+        py: Python<'_>,
+        _exc_type: PyObject,
+        _exc_value: PyObject,
+        _exc_traceback: PyObject,
+    ) -> Py<Self> {
+        slf.borrow_mut(py).bbi = BBIReadRaw::Closed;
+        slf
+    }
+
+    fn __traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
+        match &self.bbi {
+            BBIReadRaw::Closed | BBIReadRaw::BigWigFile(_) | BBIReadRaw::BigBedFile(_) => {}
+            #[cfg(feature = "remote")]
+            BBIReadRaw::BigWigRemote(_) | BBIReadRaw::BigBedRemote(_) => {}
+            BBIReadRaw::BigWigFileLike(b) => visit.call(&b.inner_read().inner_read().inner)?,
+            BBIReadRaw::BigBedFileLike(b) => visit.call(&b.inner_read().inner_read().inner)?,
         }
+        Ok(())
+    }
+
+    fn __clear__(&mut self) {
+        self.close()
     }
 }
 
@@ -1379,6 +1430,7 @@ impl ZoomIntervalIterator {
                         ("sum", v.summary.sum.to_object(slf.py())),
                         ("sum_squares", v.summary.sum_squares.to_object(slf.py())),
                     ]
+                    .into_py_dict(slf.py())
                     .to_object(slf.py());
                     (v.start, v.end, summary)
                 })
@@ -2083,6 +2135,8 @@ fn bigWigAverageOverBed(
 #[pymodule]
 fn pybigtools(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    m.add("BBIFileClosed", m.py().get_type::<BBIFileClosed>())?;
+
     m.add_wrapped(wrap_pyfunction!(open))?;
     m.add_wrapped(wrap_pyfunction!(bigWigAverageOverBed))?;
 

--- a/pybigtools/src/lib.rs
+++ b/pybigtools/src/lib.rs
@@ -313,6 +313,44 @@ struct BBIRead {
 
 #[pymethods]
 impl BBIRead {
+    fn is_bigwig(&self) -> bool {
+        #[cfg(feature = "remote")]
+        {
+            matches!(
+                self.bbi,
+                BBIReadRaw::BigWigFile(_)
+                    | BBIReadRaw::BigWigRemote(_)
+                    | BBIReadRaw::BigWigFileLike(_)
+            )
+        }
+        #[cfg(not(feature = "remote"))]
+        {
+            matches!(
+                self.bbi,
+                BBIReadRaw::BigWigFile(_) | BBIReadRaw::BigWigFileLike(_)
+            )
+        }
+    }
+
+    fn is_bigbed(&self) -> bool {
+        #[cfg(feature = "remote")]
+        {
+            matches!(
+                self.bbi,
+                BBIReadRaw::BigBedFile(_)
+                    | BBIReadRaw::BigBedRemote(_)
+                    | BBIReadRaw::BigBedFileLike(_)
+            )
+        }
+        #[cfg(not(feature = "remote"))]
+        {
+            matches!(
+                self.bbi,
+                BBIReadRaw::BigBedFile(_) | BBIReadRaw::BigBedFileLike(_)
+            )
+        }
+    }
+
     /// Returns the autosql of this bbi file.
     ///
     /// For bigBeds, this comes directly from the autosql stored in the file.

--- a/pybigtools/src/lib.rs
+++ b/pybigtools/src/lib.rs
@@ -65,6 +65,45 @@ fn start_end(
     return Ok((start.unwrap_or(0), end.unwrap_or(length)));
 }
 
+fn bigwig_start_end_length<R>(
+    bbi: &BigWigReadRaw<R>,
+    chrom_name: &str,
+    start: Option<i32>,
+    end: Option<i32>,
+) -> PyResult<(i32, i32, i32)> {
+    let chroms = bbi.chroms();
+    start_end_length_inner(chrom_name, chroms, start, end)
+}
+
+fn bigbed_start_end_length<R>(
+    bbi: &BigBedReadRaw<R>,
+    chrom_name: &str,
+    start: Option<i32>,
+    end: Option<i32>,
+) -> PyResult<(i32, i32, i32)> {
+    let chroms = bbi.chroms();
+    start_end_length_inner(chrom_name, chroms, start, end)
+}
+
+fn start_end_length_inner(
+    chrom_name: &str,
+    chroms: &[bigtools::ChromInfo],
+    start: Option<i32>,
+    end: Option<i32>,
+) -> PyResult<(i32, i32, i32)> {
+    let chrom = chroms.into_iter().find(|x| x.name == chrom_name);
+    let length = match chrom {
+        None => {
+            return Err(PyErr::new::<exceptions::PyException, _>(format!(
+                "No chromomsome with name `{}` found.",
+                chrom_name
+            )))
+        }
+        Some(c) => c.length as i32,
+    };
+    return Ok((start.unwrap_or(0), end.unwrap_or(length), length));
+}
+
 impl Reopen for PyFileLikeObject {
     fn reopen(&self) -> io::Result<Self> {
         Ok(self.clone())
@@ -116,8 +155,8 @@ impl<T, E: ToPyErr> ConvertResult<T> for Result<T, E> {
 fn intervals_to_array<R: BBIFileRead>(
     b: &mut BigWigReadRaw<R>,
     chrom: &str,
-    start: u32,
-    end: u32,
+    start: Option<i32>,
+    end: Option<i32>,
     bins: Option<usize>,
     summary: Summary,
     exact: bool,
@@ -125,6 +164,7 @@ fn intervals_to_array<R: BBIFileRead>(
     oob: f64,
     arr: Option<PyObject>,
 ) -> PyResult<PyObject> {
+    let (start, end, length) = bigwig_start_end_length(b, chrom, start, end)?;
     let zoom = if let (Some(bins), false) = (bins, exact) {
         let max_zoom_size = ((end - start) as f32 / (bins * 2) as f32) as u32;
         let zoom = b
@@ -137,14 +177,15 @@ fn intervals_to_array<R: BBIFileRead>(
     } else {
         None
     };
+    let (intervals_start, intervals_end) = (start.max(0) as u32, end.min(length) as u32);
     match (bins, zoom) {
         (Some(bins), Some(zoom)) => {
             let iter = b
-                .get_zoom_interval(&chrom, start, end, zoom.reduction_level)
+                .get_zoom_interval(&chrom, intervals_start, intervals_end, zoom.reduction_level)
                 .convert_err()?;
             Python::with_gil(|py| {
                 Ok(
-                    to_array_zoom(start as usize, end as usize, iter, summary, bins)
+                    to_array_zoom(start, end, iter, summary, bins)
                         .convert_err()?
                         .into_pyarray(py)
                         .to_object(py),
@@ -152,10 +193,10 @@ fn intervals_to_array<R: BBIFileRead>(
             })
         }
         (Some(bins), None) => {
-            let iter = b.get_interval(&chrom, start, end).convert_err()?;
+            let iter = b.get_interval(&chrom, intervals_start, intervals_end).convert_err()?;
             Python::with_gil(|py| {
                 Ok(
-                    to_array_bins(start as usize, end as usize, iter, summary, bins)
+                    to_array_bins(start, end, iter, summary, bins)
                         .convert_err()?
                         .into_pyarray(py)
                         .to_object(py),
@@ -163,9 +204,9 @@ fn intervals_to_array<R: BBIFileRead>(
             })
         }
         _ => {
-            let iter = b.get_interval(&chrom, start, end).convert_err()?;
+            let iter = b.get_interval(&chrom, intervals_start, intervals_end).convert_err()?;
             Python::with_gil(|py| {
-                Ok(to_array(start as usize, end as usize, iter)
+                Ok(to_array(start, end, iter)
                     .convert_err()?
                     .into_pyarray(py)
                     .to_object(py))
@@ -176,8 +217,8 @@ fn intervals_to_array<R: BBIFileRead>(
 fn entries_to_array<R: BBIFileRead>(
     b: &mut BigBedReadRaw<R>,
     chrom: &str,
-    start: u32,
-    end: u32,
+    start: Option<i32>,
+    end: Option<i32>,
     bins: Option<usize>,
     summary: Summary,
     exact: bool,
@@ -185,47 +226,39 @@ fn entries_to_array<R: BBIFileRead>(
     oob: f64,
     arr: Option<PyObject>,
 ) -> PyResult<PyObject> {
-    match bins {
-        Some(bins) if !exact => {
-            let max_zoom_size = ((end - start) as f32 / (bins * 2) as f32) as u32;
-            let zoom = b
-                .info()
-                .zoom_headers
-                .iter()
-                .filter(|z| z.reduction_level <= max_zoom_size)
-                .min_by_key(|z| max_zoom_size - z.reduction_level);
-            match zoom {
-                Some(zoom) => {
-                    let iter = b
-                        .get_zoom_interval(&chrom, start, end, zoom.reduction_level)
-                        .convert_err()?;
-                    Python::with_gil(|py| {
-                        Ok(
-                            to_entry_array_zoom(start as usize, end as usize, iter, summary, bins)
-                                .convert_err()?
-                                .into_pyarray(py)
-                                .to_object(py),
-                        )
-                    })
-                }
-                None => {
-                    let iter = b.get_interval(&chrom, start, end).convert_err()?;
-                    Python::with_gil(|py| {
-                        Ok(
-                            to_array_entry_bins(start as usize, end as usize, iter, summary, bins)
-                                .convert_err()?
-                                .into_pyarray(py)
-                                .to_object(py),
-                        )
-                    })
-                }
-            }
-        }
-        Some(bins) => {
-            let iter = b.get_interval(&chrom, start, end).convert_err()?;
+    let (start, end, length) = bigbed_start_end_length(b, chrom, start, end)?;
+    let zoom = if let (Some(bins), false) = (bins, exact) {
+        let max_zoom_size = ((end - start) as f32 / (bins * 2) as f32) as u32;
+        let zoom = b
+            .info()
+            .zoom_headers
+            .iter()
+            .filter(|z| z.reduction_level <= max_zoom_size)
+            .min_by_key(|z| max_zoom_size - z.reduction_level);
+        zoom
+    } else {
+        None
+    };
+    let (intervals_start, intervals_end) = (start.max(0) as u32, end.min(length) as u32);
+    match (bins, zoom) {
+        (Some(bins), Some(zoom)) => {
+            let iter = b
+                .get_zoom_interval(&chrom, intervals_start, intervals_end, zoom.reduction_level)
+                .convert_err()?;
             Python::with_gil(|py| {
                 Ok(
-                    to_array_entry_bins(start as usize, end as usize, iter, summary, bins)
+                    to_entry_array_zoom(start, end, iter, summary, bins)
+                        .convert_err()?
+                        .into_pyarray(py)
+                        .to_object(py),
+                )
+            })
+        }
+        (Some(bins), None) => {
+            let iter = b.get_interval(&chrom, intervals_start, intervals_end).convert_err()?;
+            Python::with_gil(|py| {
+                Ok(
+                    to_entry_array_bins(start, end, iter, summary, bins)
                         .convert_err()?
                         .into_pyarray(py)
                         .to_object(py),
@@ -233,9 +266,9 @@ fn entries_to_array<R: BBIFileRead>(
             })
         }
         _ => {
-            let iter = b.get_interval(&chrom, start, end).convert_err()?;
+            let iter = b.get_interval(&chrom, intervals_start, intervals_end).convert_err()?;
             Python::with_gil(|py| {
-                Ok(to_entry_array(start as usize, end as usize, iter)
+                Ok(to_entry_array(start, end, iter)
                     .convert_err()?
                     .into_pyarray(py)
                     .to_object(py))
@@ -244,16 +277,16 @@ fn entries_to_array<R: BBIFileRead>(
     }
 }
 fn to_array<I: Iterator<Item = Result<Value, BBIReadError>>>(
-    start: usize,
-    end: usize,
+    start: i32,
+    end: i32,
     iter: I,
 ) -> Result<Array1<f64>, BBIReadError> {
     use numpy::ndarray::Array;
-    let mut v = vec![f64::NAN; end - start];
+    let mut v = vec![f64::NAN; (end - start) as usize];
     for interval in iter {
         let interval = interval?;
-        let interval_start = (interval.start as usize) - start;
-        let interval_end = (interval.end as usize) - start;
+        let interval_start = ((interval.start as i32) - start) as usize;
+        let interval_end = ((interval.end as i32) - start) as usize;
         for i in v[interval_start..interval_end].iter_mut() {
             *i = interval.value as f64;
         }
@@ -261,8 +294,8 @@ fn to_array<I: Iterator<Item = Result<Value, BBIReadError>>>(
     Ok(Array::from(v))
 }
 fn to_array_bins<I: Iterator<Item = Result<Value, BBIReadError>>>(
-    start: usize,
-    end: usize,
+    start: i32,
+    end: i32,
     iter: I,
     summary: Summary,
     bins: usize,
@@ -275,8 +308,8 @@ fn to_array_bins<I: Iterator<Item = Result<Value, BBIReadError>>>(
     let bin_size = (end - start) as f64 / bins as f64;
     for interval in iter {
         let interval = interval?;
-        let interval_start = (interval.start as usize) - start;
-        let interval_end = (interval.end as usize) - start;
+        let interval_start = (interval.start as i32) - start;
+        let interval_end = (interval.end as i32) - start;
         let bin_start = ((interval_start as f64) / bin_size) as usize;
         let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
         for bin in bin_start..bin_end {
@@ -312,8 +345,8 @@ fn to_array_bins<I: Iterator<Item = Result<Value, BBIReadError>>>(
     Ok(Array::from(v))
 }
 fn to_array_zoom<I: Iterator<Item = Result<ZoomRecord, BBIReadError>>>(
-    start: usize,
-    end: usize,
+    start: i32,
+    end: i32,
     iter: I,
     summary: Summary,
     bins: usize,
@@ -326,8 +359,8 @@ fn to_array_zoom<I: Iterator<Item = Result<ZoomRecord, BBIReadError>>>(
     let bin_size = (end - start) as f64 / bins as f64;
     for interval in iter {
         let interval = interval?;
-        let interval_start = (interval.start as usize).max(start) - start;
-        let interval_end = (interval.end as usize).min(end) - start;
+        let interval_start = (interval.start as i32).max(start) - start;
+        let interval_end = (interval.end as i32).min(end) - start;
         let bin_start = ((interval_start as f64) / bin_size) as usize;
         let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
         for bin in bin_start..bin_end {
@@ -365,37 +398,37 @@ fn to_array_zoom<I: Iterator<Item = Result<ZoomRecord, BBIReadError>>>(
     Ok(Array::from(v))
 }
 fn to_entry_array<I: Iterator<Item = Result<BedEntry, BBIReadError>>>(
-    start: usize,
-    end: usize,
+    start: i32,
+    end: i32,
     iter: I,
 ) -> Result<Array1<f64>, BBIReadError> {
     use numpy::ndarray::Array;
-    let mut v = vec![0.0; end - start];
+    let mut v = vec![0.0; (end - start) as usize];
     for interval in iter {
         let interval = interval?;
-        let interval_start = (interval.start as usize) - start;
-        let interval_end = (interval.end as usize) - start;
+        let interval_start = ((interval.start as i32) - start) as usize;
+        let interval_end = ((interval.end as i32) - start) as usize;
         for i in v[interval_start..interval_end].iter_mut() {
             *i += 1.0;
         }
     }
     Ok(Array::from(v))
 }
-fn to_array_entry_bins<I: Iterator<Item = Result<BedEntry, BBIReadError>>>(
-    start: usize,
-    end: usize,
+fn to_entry_array_bins<I: Iterator<Item = Result<BedEntry, BBIReadError>>>(
+    start: i32,
+    end: i32,
     iter: I,
     summary: Summary,
     bins: usize,
 ) -> Result<Array1<f64>, BBIReadError> {
     use numpy::ndarray::Array;
-    let mut bin_data: VecDeque<(usize, usize, usize, Vec<f64>)> = VecDeque::new();
+    let mut bin_data: VecDeque<(usize, i32, i32, Vec<f64>)> = VecDeque::new();
     let mut v = vec![0.0; bins];
     let bin_size = (end - start) as f64 / bins as f64;
     for interval in iter {
         let interval = interval?;
-        let interval_start = (interval.start as usize).max(start) - start;
-        let interval_end = (interval.end as usize).min(end) - start;
+        let interval_start = (interval.start as i32).max(start) - start;
+        let interval_end = (interval.end as i32).min(end) - start;
         let bin_start = ((interval_start as f64) / bin_size) as usize;
         let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
 
@@ -432,10 +465,10 @@ fn to_array_entry_bins<I: Iterator<Item = Result<BedEntry, BBIReadError>>>(
             .map(|b| ((b.0 + 1) < bin_end).then(|| b.0 + 1))
             .unwrap_or(Some(bin_start))
         {
-            let bin_start = ((bin as f64) * bin_size).ceil() as usize;
-            let bin_end = (((bin + 1) as f64) * bin_size).ceil() as usize;
+            let bin_start = ((bin as f64) * bin_size).ceil() as i32;
+            let bin_end = (((bin + 1) as f64) * bin_size).ceil() as i32;
 
-            bin_data.push_back((bin, bin_start, bin_end, vec![0.0; bin_end - bin_start]));
+            bin_data.push_back((bin, bin_start, bin_end, vec![0.0; (bin_end - bin_start) as usize]));
         }
         for bin in bin_data.iter() {
             assert!(
@@ -453,7 +486,7 @@ fn to_array_entry_bins<I: Iterator<Item = Result<BedEntry, BBIReadError>>>(
             let overlap_start = (*bin_start).max(interval_start);
             let overlap_end = (*bin_end).min(interval_end);
 
-            for i in &mut data[(overlap_start - *bin_start)..(overlap_end - *bin_start)] {
+            for i in &mut data[((overlap_start - *bin_start) as usize)..((overlap_end - *bin_start) as usize)] {
                 *i = *i + 1.0;
             }
         }
@@ -485,20 +518,20 @@ fn to_array_entry_bins<I: Iterator<Item = Result<BedEntry, BBIReadError>>>(
 }
 
 fn to_entry_array_zoom<I: Iterator<Item = Result<ZoomRecord, BBIReadError>>>(
-    start: usize,
-    end: usize,
+    start: i32,
+    end: i32,
     iter: I,
     summary: Summary,
     bins: usize,
 ) -> Result<Array1<f64>, BBIReadError> {
     use numpy::ndarray::Array;
-    let mut bin_data: VecDeque<(usize, usize, usize, Vec<f64>)> = VecDeque::new();
+    let mut bin_data: VecDeque<(usize, i32, i32, Vec<f64>)> = VecDeque::new();
     let mut v = vec![0.0; bins];
     let bin_size = (end - start) as f64 / bins as f64;
     for interval in iter {
         let interval = interval?;
-        let interval_start = (interval.start as usize).max(start) - start;
-        let interval_end = (interval.end as usize).min(end) - start;
+        let interval_start = (interval.start as i32).max(start) - start;
+        let interval_end = (interval.end as i32).min(end) - start;
         let bin_start = ((interval_start as f64) / bin_size) as usize;
         let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
 
@@ -537,10 +570,10 @@ fn to_entry_array_zoom<I: Iterator<Item = Result<ZoomRecord, BBIReadError>>>(
             .map(|b| ((b.0 + 1) < bin_end).then(|| b.0 + 1))
             .unwrap_or(Some(bin_start))
         {
-            let bin_start = ((bin as f64) * bin_size).ceil() as usize;
-            let bin_end = (((bin + 1) as f64) * bin_size).ceil() as usize;
+            let bin_start = ((bin as f64) * bin_size).ceil() as i32;
+            let bin_end = (((bin + 1) as f64) * bin_size).ceil() as i32;
 
-            bin_data.push_back((bin, bin_start, bin_end, vec![f64::NAN; bin_end - bin_start]));
+            bin_data.push_back((bin, bin_start, bin_end, vec![f64::NAN; (bin_end - bin_start) as usize]));
         }
         for bin in bin_data.iter() {
             assert!(
@@ -559,7 +592,7 @@ fn to_entry_array_zoom<I: Iterator<Item = Result<ZoomRecord, BBIReadError>>>(
             let overlap_end = (*bin_end).min(interval_end);
 
             let mean = interval.summary.sum / (interval.end - interval.start) as f64;
-            for i in &mut data[(overlap_start - *bin_start)..(overlap_end - *bin_start)] {
+            for i in &mut data[((overlap_start - *bin_start) as usize)..((overlap_end - *bin_start) as usize)] {
                 match summary {
                     Summary::Mean => *i += mean,
                     Summary::Min => *i = i.min(interval.summary.min_val),
@@ -798,8 +831,8 @@ impl BBIRead {
     fn values(
         &mut self,
         chrom: String,
-        start: Option<u32>,
-        end: Option<u32>,
+        start: Option<i32>,
+        end: Option<i32>,
         bins: Option<usize>,
         summary: String,
         exact: bool,
@@ -817,7 +850,6 @@ impl BBIRead {
                 )));
             }
         };
-        let (start, end) = start_end(&self.bbi, &chrom, start, end)?;
         match &mut self.bbi {
             BBIReadRaw::BigWigFile(b) => intervals_to_array(
                 b, &chrom, start, end, bins, summary, exact, missing, oob, arr,
@@ -1596,16 +1628,16 @@ fn pybigtools(_py: Python, m: &PyModule) -> PyResult<()> {
 mod test {
     use bigtools::BedEntry;
 
-    use crate::to_array_entry_bins;
+    use crate::to_entry_array_bins;
 
     #[test]
-    fn test_to_array_entry_bins() {
+    fn test_to_entry_array_bins() {
         let entries = [BedEntry {
             start: 10,
             end: 20,
             rest: "".to_string(),
         }];
-        let res = to_array_entry_bins(
+        let res = to_entry_array_bins(
             10,
             20,
             entries.into_iter().map(|v| Ok(v)),
@@ -1621,7 +1653,7 @@ mod test {
             end: 20,
             rest: "".to_string(),
         }];
-        let res = to_array_entry_bins(
+        let res = to_entry_array_bins(
             10,
             20,
             entries.into_iter().map(|v| Ok(v)),
@@ -1644,7 +1676,7 @@ mod test {
                 rest: "".to_string(),
             },
         ];
-        let res = to_array_entry_bins(
+        let res = to_entry_array_bins(
             10,
             20,
             entries.clone().into_iter().map(|v| Ok(v)),
@@ -1654,7 +1686,7 @@ mod test {
         .unwrap();
         let res = res.to_vec();
         assert_eq!(res, [1.0, 2.0].into_iter().collect::<Vec<_>>());
-        let res = to_array_entry_bins(
+        let res = to_entry_array_bins(
             10,
             20,
             entries.clone().into_iter().map(|v| Ok(v)),
@@ -1664,7 +1696,7 @@ mod test {
         .unwrap();
         let res = res.to_vec();
         assert_eq!(res, [1.0].into_iter().collect::<Vec<_>>());
-        let res = to_array_entry_bins(
+        let res = to_entry_array_bins(
             10,
             20,
             entries.clone().into_iter().map(|v| Ok(v)),
@@ -1692,7 +1724,7 @@ mod test {
                 rest: "".to_string(),
             },
         ];
-        let res = to_array_entry_bins(
+        let res = to_entry_array_bins(
             10,
             20,
             entries.clone().into_iter().map(|v| Ok(v)),
@@ -1702,7 +1734,7 @@ mod test {
         .unwrap();
         let res = res.to_vec();
         assert_eq!(res, [1.0, 3.0].into_iter().collect::<Vec<_>>());
-        let res = to_array_entry_bins(
+        let res = to_entry_array_bins(
             10,
             20,
             entries.clone().into_iter().map(|v| Ok(v)),
@@ -1712,7 +1744,7 @@ mod test {
         .unwrap();
         let res = res.to_vec();
         assert_eq!(res, [1.0].into_iter().collect::<Vec<_>>());
-        let res = to_array_entry_bins(
+        let res = to_entry_array_bins(
             10,
             20,
             entries.clone().into_iter().map(|v| Ok(v)),

--- a/pybigtools/src/lib.rs
+++ b/pybigtools/src/lib.rs
@@ -926,6 +926,7 @@ struct BBIRead {
 
 #[pymethods]
 impl BBIRead {
+    #[getter]
     fn is_bigwig(&self) -> bool {
         #[cfg(feature = "remote")]
         {
@@ -945,6 +946,7 @@ impl BBIRead {
         }
     }
 
+    #[getter]
     fn is_bigbed(&self) -> bool {
         #[cfg(feature = "remote")]
         {

--- a/pybigtools/src/lib.rs
+++ b/pybigtools/src/lib.rs
@@ -964,6 +964,65 @@ impl BBIRead {
         }
     }
 
+    fn info(&mut self, py: Python<'_>) -> PyResult<PyObject> {
+        let (info, summary) = match &mut self.bbi {
+            BBIReadRaw::BigWigFile(b) => {
+                let summary = b.get_summary()?;
+                (b.info(), summary)
+            }
+            BBIReadRaw::BigWigRemote(b) => {
+                let summary = b.get_summary()?;
+                (b.info(), summary)
+            }
+            BBIReadRaw::BigWigFileLike(b) => {
+                let summary = b.get_summary()?;
+                (b.info(), summary)
+            }
+            BBIReadRaw::BigBedFile(b) => {
+                let summary = b.get_summary()?;
+                (b.info(), summary)
+            }
+            BBIReadRaw::BigBedRemote(b) => {
+                let summary = b.get_summary()?;
+                (b.info(), summary)
+            }
+            BBIReadRaw::BigBedFileLike(b) => {
+                let summary = b.get_summary()?;
+                (b.info(), summary)
+            }
+        };
+        let var = (summary.sum_squares
+            - (summary.sum * summary.sum) / summary.bases_covered as f64)
+            / (summary.bases_covered as f64 - 1.0);
+        let summary = [
+            ("basesCovered", summary.bases_covered.to_object(py)),
+            ("sum", summary.sum.to_object(py)),
+            (
+                "mean",
+                (summary.sum as f64 / summary.bases_covered as f64).to_object(py),
+            ),
+            ("min", summary.min_val.to_object(py)),
+            ("max", summary.max_val.to_object(py)),
+            ("std", f64::sqrt(var).to_object(py)),
+        ]
+        .into_py_dict(py)
+        .to_object(py);
+        let info = [
+            ("version", info.header.version.to_object(py)),
+            ("isCompressed", info.header.is_compressed().to_object(py)),
+            (
+                "primaryDataSize",
+                info.header.primary_data_size().to_object(py),
+            ),
+            ("zoomLevels", info.zoom_headers.len().to_object(py)),
+            ("chromCount", info.chrom_info.len().to_object(py)),
+            ("summary", summary),
+        ]
+        .into_py_dict(py)
+        .to_object(py);
+        Ok(info)
+    }
+
     /// Returns the autosql of this bbi file.
     ///
     /// For bigBeds, this comes directly from the autosql stored in the file.

--- a/pybigtools/src/lib.rs
+++ b/pybigtools/src/lib.rs
@@ -1141,10 +1141,10 @@ impl BBIRead {
             BBIReadRaw::BigWigFile(_) | BBIReadRaw::BigWigFileLike(_) => BEDGRAPH.to_string(),
             #[cfg(feature = "remote")]
             BBIReadRaw::BigWigRemote(_) => BEDGRAPH.to_string(),
-            BBIReadRaw::BigBedFile(b) => b.autosql().convert_err()?,
+            BBIReadRaw::BigBedFile(b) => b.autosql().convert_err()?.unwrap_or(String::new()),
             #[cfg(feature = "remote")]
-            BBIReadRaw::BigBedRemote(b) => b.autosql().convert_err()?,
-            BBIReadRaw::BigBedFileLike(b) => b.autosql().convert_err()?,
+            BBIReadRaw::BigBedRemote(b) => b.autosql().convert_err()?.unwrap_or(String::new()),
+            BBIReadRaw::BigBedFileLike(b) => b.autosql().convert_err()?.unwrap_or(String::new()),
         };
         let obj = if parse {
             let mut declarations = parse_autosql(&schema)

--- a/pybigtools/src/lib.rs
+++ b/pybigtools/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(non_snake_case)]
 
+use std::collections::VecDeque;
 use std::fs::File;
 use std::io::{self, BufReader};
 use std::path::Path;
@@ -21,6 +22,7 @@ use bigtools::{
 
 use bigtools::utils::reopen::Reopen;
 use file_like::PyFileLikeObject;
+use numpy::ndarray::Array1;
 use numpy::IntoPyArray;
 use pyo3::exceptions::{self, PyTypeError};
 use pyo3::prelude::*;
@@ -79,6 +81,229 @@ enum BBIReadRaw {
     #[cfg(feature = "remote")]
     BigBedRemote(BigBedReadRaw<CachedBBIFileRead<RemoteFile>>),
     BigBedFileLike(BigBedReadRaw<CachedBBIFileRead<PyFileLikeObject>>),
+}
+
+#[derive(Copy, Clone, Debug)]
+enum Summary {
+    Mean,
+    Min,
+    Max,
+}
+
+fn to_array_entry_bins<I: Iterator<Item = Result<BedEntry, BBIReadError>>>(
+    start: usize,
+    end: usize,
+    iter: I,
+    summary: Summary,
+    bins: usize,
+) -> Result<Array1<f64>, BBIReadError> {
+    use numpy::ndarray::Array;
+    let mut bin_data: VecDeque<(usize, usize, usize, Vec<f64>)> = VecDeque::new();
+    let mut v = vec![0.0; bins];
+    let bin_size = (end - start) as f64 / bins as f64;
+    for interval in iter {
+        let interval = interval?;
+        let interval_start = (interval.start as usize).max(start) - start;
+        let interval_end = (interval.end as usize).min(end) - start;
+        let bin_start = ((interval_start as f64) / bin_size) as usize;
+        let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
+
+        while let Some(front) = bin_data.front_mut() {
+            if front.0 < bin_start {
+                let front = bin_data.pop_front().unwrap();
+                let bin = front.0;
+
+                match summary {
+                    Summary::Min => {
+                        v[bin] = front
+                            .3
+                            .into_iter()
+                            .reduce(|min, v| min.min(v))
+                            .unwrap_or(0.0);
+                    }
+                    Summary::Max => {
+                        v[bin] = front
+                            .3
+                            .into_iter()
+                            .reduce(|max, v| max.max(v))
+                            .unwrap_or(0.0);
+                    }
+                    Summary::Mean => {
+                        v[bin] = front.3.into_iter().sum::<f64>() / bin_size;
+                    }
+                }
+            } else {
+                break;
+            }
+        }
+        while let Some(bin) = bin_data
+            .back_mut()
+            .map(|b| ((b.0 + 1) < bin_end).then(|| b.0 + 1))
+            .unwrap_or(Some(bin_start))
+        {
+            let bin_start = ((bin as f64) * bin_size).ceil() as usize;
+            let bin_end = (((bin + 1) as f64) * bin_size).ceil() as usize;
+
+            bin_data.push_back((bin, bin_start, bin_end, vec![0.0; bin_end - bin_start]));
+        }
+        for bin in bin_data.iter() {
+            assert!(
+                (bin_start..bin_end).contains(&bin.0),
+                "{} not in {}..{}",
+                bin.0,
+                bin_start,
+                bin_end
+            );
+        }
+        for bin in bin_start..bin_end {
+            assert!(bin_data.iter().find(|b| b.0 == bin).is_some());
+        }
+        for (_bin, bin_start, bin_end, data) in bin_data.iter_mut() {
+            let overlap_start = (*bin_start).max(interval_start);
+            let overlap_end = (*bin_end).min(interval_end);
+
+            for i in &mut data[(overlap_start - *bin_start)..(overlap_end - *bin_start)] {
+                *i = *i + 1.0;
+            }
+        }
+    }
+    while let Some(front) = bin_data.pop_front() {
+        let bin = front.0;
+
+        match summary {
+            Summary::Min => {
+                v[bin] = front
+                    .3
+                    .into_iter()
+                    .reduce(|min, v| min.min(v))
+                    .unwrap_or(0.0);
+            }
+            Summary::Max => {
+                v[bin] = front
+                    .3
+                    .into_iter()
+                    .reduce(|max, v| max.max(v))
+                    .unwrap_or(0.0);
+            }
+            Summary::Mean => {
+                v[bin] = front.3.into_iter().sum::<f64>() / bin_size;
+            }
+        }
+    }
+    Ok(Array::from(v))
+}
+
+fn to_entry_array_zoom<I: Iterator<Item = Result<ZoomRecord, BBIReadError>>>(
+    start: usize,
+    end: usize,
+    iter: I,
+    summary: Summary,
+    bins: usize,
+) -> Result<Array1<f64>, BBIReadError> {
+    use numpy::ndarray::Array;
+    let mut bin_data: VecDeque<(usize, usize, usize, Vec<f64>)> = VecDeque::new();
+    let mut v = vec![0.0; bins];
+    let bin_size = (end - start) as f64 / bins as f64;
+    for interval in iter {
+        let interval = interval?;
+        let interval_start = (interval.start as usize).max(start) - start;
+        let interval_end = (interval.end as usize).min(end) - start;
+        let bin_start = ((interval_start as f64) / bin_size) as usize;
+        let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
+
+        while let Some(front) = bin_data.front_mut() {
+            if front.0 < bin_start {
+                let front = bin_data.pop_front().unwrap();
+                let bin = front.0;
+
+                match summary {
+                    Summary::Min => {
+                        v[bin] = front
+                            .3
+                            .into_iter()
+                            .reduce(|min, v| min.min(v))
+                            .unwrap_or(0.0)
+                            .max(0.0);
+                    }
+                    Summary::Max => {
+                        v[bin] = front
+                            .3
+                            .into_iter()
+                            .reduce(|max, v| max.max(v))
+                            .unwrap_or(0.0)
+                            .max(0.0);
+                    }
+                    Summary::Mean => {
+                        v[bin] = front.3.into_iter().sum::<f64>() / bin_size;
+                    }
+                }
+            } else {
+                break;
+            }
+        }
+        while let Some(bin) = bin_data
+            .back_mut()
+            .map(|b| ((b.0 + 1) < bin_end).then(|| b.0 + 1))
+            .unwrap_or(Some(bin_start))
+        {
+            let bin_start = ((bin as f64) * bin_size).ceil() as usize;
+            let bin_end = (((bin + 1) as f64) * bin_size).ceil() as usize;
+
+            bin_data.push_back((bin, bin_start, bin_end, vec![f64::NAN; bin_end - bin_start]));
+        }
+        for bin in bin_data.iter() {
+            assert!(
+                (bin_start..bin_end).contains(&bin.0),
+                "{} not in {}..{}",
+                bin.0,
+                bin_start,
+                bin_end
+            );
+        }
+        for bin in bin_start..bin_end {
+            assert!(bin_data.iter().find(|b| b.0 == bin).is_some());
+        }
+        for (_bin, bin_start, bin_end, data) in bin_data.iter_mut() {
+            let overlap_start = (*bin_start).max(interval_start);
+            let overlap_end = (*bin_end).min(interval_end);
+
+            let mean = interval.summary.sum / (interval.end - interval.start) as f64;
+            for i in &mut data[(overlap_start - *bin_start)..(overlap_end - *bin_start)] {
+                match summary {
+                    Summary::Mean => *i += mean,
+                    Summary::Min => *i = i.min(interval.summary.min_val),
+                    Summary::Max => *i = i.max(interval.summary.max_val),
+                }
+                *i = i.max(0.0);
+            }
+        }
+    }
+    while let Some(front) = bin_data.pop_front() {
+        let bin = front.0;
+
+        match summary {
+            Summary::Min => {
+                v[bin] = front
+                    .3
+                    .into_iter()
+                    .reduce(|min, v| min.min(v))
+                    .unwrap_or(0.0)
+                    .max(0.0);
+            }
+            Summary::Max => {
+                v[bin] = front
+                    .3
+                    .into_iter()
+                    .reduce(|max, v| max.max(v))
+                    .unwrap_or(0.0)
+                    .max(0.0);
+            }
+            Summary::Mean => {
+                v[bin] = front.3.into_iter().sum::<f64>() / bin_size;
+            }
+        }
+    }
+    Ok(Array::from(v))
 }
 
 /// This class is the interface for reading a bigWig or bigBed.
@@ -255,12 +480,6 @@ impl BBIRead {
         summary: Option<String>,
         exact: Option<bool>,
     ) -> PyResult<PyObject> {
-        enum Summary {
-            Mean,
-            Min,
-            Max,
-        }
-        use numpy::ndarray::Array1;
         fn to_array<I: Iterator<Item = Result<Value, BBIReadError>>>(
             start: usize,
             end: usize,
@@ -399,48 +618,6 @@ impl BBIRead {
             }
             Ok(Array::from(v))
         }
-        fn to_array_entry_bins<I: Iterator<Item = Result<BedEntry, BBIReadError>>>(
-            start: usize,
-            end: usize,
-            iter: I,
-            bins: usize,
-        ) -> Result<Array1<f64>, BBIReadError> {
-            use numpy::ndarray::Array;
-            let mut v = vec![0.0; bins];
-            let bin_size = (end - start) as f64 / bins as f64;
-            for interval in iter {
-                let interval = interval?;
-                let interval_start = (interval.start as usize) - start;
-                let interval_end = (interval.end as usize) - start;
-                let bin_start = ((interval_start as f64) / bin_size) as usize;
-                let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
-                for bin in bin_start..bin_end {
-                    v[bin] += 1.0;
-                }
-            }
-            Ok(Array::from(v))
-        }
-        fn to_entry_array_zoom<I: Iterator<Item = Result<ZoomRecord, BBIReadError>>>(
-            start: usize,
-            end: usize,
-            iter: I,
-            bins: usize,
-        ) -> Result<Array1<f64>, BBIReadError> {
-            use numpy::ndarray::Array;
-            let mut v = vec![0.0; bins];
-            let bin_size = (end - start) as f64 / bins as f64;
-            for interval in iter {
-                let interval = interval?;
-                let interval_start = (interval.start as usize).max(start) - start;
-                let interval_end = (interval.end as usize).min(end) - start;
-                let bin_start = ((interval_start as f64) / bin_size) as usize;
-                let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
-                for bin in bin_start..bin_end {
-                    v[bin] += interval.summary.total_items as f64;
-                }
-            }
-            Ok(Array::from(v))
-        }
 
         let summary = match summary.as_deref() {
             None => Summary::Mean,
@@ -555,6 +732,7 @@ impl BBIRead {
             start: u32,
             end: u32,
             bins: Option<usize>,
+            summary: Summary,
             exact: Option<bool>,
         ) -> PyResult<PyObject> {
             match bins {
@@ -574,17 +752,18 @@ impl BBIRead {
                                     PyErr::new::<exceptions::PyException, _>(format!("{}", e))
                                 })?;
                             Python::with_gil(|py| {
-                                Ok(
-                                    to_entry_array_zoom(start as usize, end as usize, iter, bins)
-                                        .map_err(|e| {
-                                            PyErr::new::<exceptions::PyException, _>(format!(
-                                                "{}",
-                                                e
-                                            ))
-                                        })?
-                                        .into_pyarray(py)
-                                        .to_object(py),
+                                Ok(to_entry_array_zoom(
+                                    start as usize,
+                                    end as usize,
+                                    iter,
+                                    summary,
+                                    bins,
                                 )
+                                .map_err(|e| {
+                                    PyErr::new::<exceptions::PyException, _>(format!("{}", e))
+                                })?
+                                .into_pyarray(py)
+                                .to_object(py))
                             })
                         }
                         None => {
@@ -592,17 +771,18 @@ impl BBIRead {
                                 PyErr::new::<exceptions::PyException, _>(format!("{}", e))
                             })?;
                             Python::with_gil(|py| {
-                                Ok(
-                                    to_array_entry_bins(start as usize, end as usize, iter, bins)
-                                        .map_err(|e| {
-                                            PyErr::new::<exceptions::PyException, _>(format!(
-                                                "{}",
-                                                e
-                                            ))
-                                        })?
-                                        .into_pyarray(py)
-                                        .to_object(py),
+                                Ok(to_array_entry_bins(
+                                    start as usize,
+                                    end as usize,
+                                    iter,
+                                    summary,
+                                    bins,
                                 )
+                                .map_err(|e| {
+                                    PyErr::new::<exceptions::PyException, _>(format!("{}", e))
+                                })?
+                                .into_pyarray(py)
+                                .to_object(py))
                             })
                         }
                     }
@@ -613,7 +793,7 @@ impl BBIRead {
                         .map_err(|e| PyErr::new::<exceptions::PyException, _>(format!("{}", e)))?;
                     Python::with_gil(|py| {
                         Ok(
-                            to_array_entry_bins(start as usize, end as usize, iter, bins)
+                            to_array_entry_bins(start as usize, end as usize, iter, summary, bins)
                                 .map_err(|e| {
                                     PyErr::new::<exceptions::PyException, _>(format!("{}", e))
                                 })?
@@ -648,10 +828,16 @@ impl BBIRead {
             BBIReadRaw::BigWigFileLike(b) => {
                 intervals_to_array(b, &chrom, start, end, bins, summary, exact)
             }
-            BBIReadRaw::BigBedFile(b) => entries_to_array(b, &chrom, start, end, bins, exact),
+            BBIReadRaw::BigBedFile(b) => {
+                entries_to_array(b, &chrom, start, end, bins, summary, exact)
+            }
             #[cfg(feature = "remote")]
-            BBIReadRaw::BigBedRemote(b) => entries_to_array(b, &chrom, start, end, bins, exact),
-            BBIReadRaw::BigBedFileLike(b) => entries_to_array(b, &chrom, start, end, bins, exact),
+            BBIReadRaw::BigBedRemote(b) => {
+                entries_to_array(b, &chrom, start, end, bins, summary, exact)
+            }
+            BBIReadRaw::BigBedFileLike(b) => {
+                entries_to_array(b, &chrom, start, end, bins, summary, exact)
+            }
         }
     }
 
@@ -1396,4 +1582,137 @@ fn pybigtools(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<BigBedEntriesIterator>()?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use bigtools::BedEntry;
+
+    use crate::to_array_entry_bins;
+
+    #[test]
+    fn test_to_array_entry_bins() {
+        let entries = [BedEntry {
+            start: 10,
+            end: 20,
+            rest: "".to_string(),
+        }];
+        let res = to_array_entry_bins(
+            10,
+            20,
+            entries.into_iter().map(|v| Ok(v)),
+            crate::Summary::Mean,
+            1,
+        )
+        .unwrap();
+        let res = res.to_vec();
+        assert_eq!(res, [1.0].into_iter().collect::<Vec<_>>());
+
+        let entries = [BedEntry {
+            start: 10,
+            end: 20,
+            rest: "".to_string(),
+        }];
+        let res = to_array_entry_bins(
+            10,
+            20,
+            entries.into_iter().map(|v| Ok(v)),
+            crate::Summary::Mean,
+            2,
+        )
+        .unwrap();
+        let res = res.to_vec();
+        assert_eq!(res, [1.0, 1.0].into_iter().collect::<Vec<_>>());
+
+        let entries = [
+            BedEntry {
+                start: 10,
+                end: 20,
+                rest: "".to_string(),
+            },
+            BedEntry {
+                start: 15,
+                end: 20,
+                rest: "".to_string(),
+            },
+        ];
+        let res = to_array_entry_bins(
+            10,
+            20,
+            entries.clone().into_iter().map(|v| Ok(v)),
+            crate::Summary::Mean,
+            2,
+        )
+        .unwrap();
+        let res = res.to_vec();
+        assert_eq!(res, [1.0, 2.0].into_iter().collect::<Vec<_>>());
+        let res = to_array_entry_bins(
+            10,
+            20,
+            entries.clone().into_iter().map(|v| Ok(v)),
+            crate::Summary::Min,
+            1,
+        )
+        .unwrap();
+        let res = res.to_vec();
+        assert_eq!(res, [1.0].into_iter().collect::<Vec<_>>());
+        let res = to_array_entry_bins(
+            10,
+            20,
+            entries.clone().into_iter().map(|v| Ok(v)),
+            crate::Summary::Max,
+            1,
+        )
+        .unwrap();
+        let res = res.to_vec();
+        assert_eq!(res, [2.0].into_iter().collect::<Vec<_>>());
+
+        let entries = [
+            BedEntry {
+                start: 10,
+                end: 20,
+                rest: "".to_string(),
+            },
+            BedEntry {
+                start: 15,
+                end: 20,
+                rest: "".to_string(),
+            },
+            BedEntry {
+                start: 15,
+                end: 25,
+                rest: "".to_string(),
+            },
+        ];
+        let res = to_array_entry_bins(
+            10,
+            20,
+            entries.clone().into_iter().map(|v| Ok(v)),
+            crate::Summary::Mean,
+            2,
+        )
+        .unwrap();
+        let res = res.to_vec();
+        assert_eq!(res, [1.0, 3.0].into_iter().collect::<Vec<_>>());
+        let res = to_array_entry_bins(
+            10,
+            20,
+            entries.clone().into_iter().map(|v| Ok(v)),
+            crate::Summary::Min,
+            1,
+        )
+        .unwrap();
+        let res = res.to_vec();
+        assert_eq!(res, [1.0].into_iter().collect::<Vec<_>>());
+        let res = to_array_entry_bins(
+            10,
+            20,
+            entries.clone().into_iter().map(|v| Ok(v)),
+            crate::Summary::Max,
+            1,
+        )
+        .unwrap();
+        let res = res.to_vec();
+        assert_eq!(res, [3.0].into_iter().collect::<Vec<_>>());
+    }
 }

--- a/pybigtools/src/lib.rs
+++ b/pybigtools/src/lib.rs
@@ -4,6 +4,7 @@ use std::fs::File;
 use std::io::{self, BufReader};
 use std::path::Path;
 
+use bigtools::bed::autosql::parse::parse_autosql;
 use bigtools::bed::bedparser::BedParser;
 use bigtools::bedchromdata::BedParserStreamingIterator;
 #[cfg(feature = "remote")]
@@ -13,9 +14,9 @@ use bigtools::utils::misc::{
     bigwig_average_over_bed, BigWigAverageOverBedEntry, BigWigAverageOverBedError, Name,
 };
 use bigtools::{
-    BBIReadError, BedEntry, BigBedRead as BigBedReadRaw, BigBedWrite as BigBedWriteRaw,
-    BigWigRead as BigWigReadRaw, BigWigWrite as BigWigWriteRaw, CachedBBIFileRead, Value,
-    ZoomRecord,
+    BBIFileRead, BBIReadError, BedEntry, BigBedRead as BigBedReadRaw,
+    BigBedWrite as BigBedWriteRaw, BigWigRead as BigWigReadRaw, BigWigWrite as BigWigWriteRaw,
+    CachedBBIFileRead, Value, ZoomRecord,
 };
 
 use bigtools::utils::reopen::Reopen;
@@ -34,13 +35,23 @@ mod file_like;
 type ValueTuple = (u32, u32, f32);
 type BedEntryTuple = (u32, u32, String);
 
-fn start_end<B: BBIFile>(
-    bbi: &B,
+fn start_end(
+    bbi: &BBIReadRaw,
     chrom_name: &str,
     start: Option<u32>,
     end: Option<u32>,
 ) -> PyResult<(u32, u32)> {
-    let chrom = bbi.chroms().into_iter().find(|x| x.name == chrom_name);
+    let chroms = match &bbi {
+        BBIReadRaw::BigWigFile(b) => b.chroms(),
+        #[cfg(feature = "remote")]
+        BBIReadRaw::BigWigRemote(b) => b.chroms(),
+        BBIReadRaw::BigWigFileLike(b) => b.chroms(),
+        BBIReadRaw::BigBedFile(b) => b.chroms(),
+        #[cfg(feature = "remote")]
+        BBIReadRaw::BigBedRemote(b) => b.chroms(),
+        BBIReadRaw::BigBedFileLike(b) => b.chroms(),
+    };
+    let chrom = chroms.into_iter().find(|x| x.name == chrom_name);
     let length = match chrom {
         None => {
             return Err(PyErr::new::<exceptions::PyException, _>(format!(
@@ -59,88 +70,175 @@ impl Reopen for PyFileLikeObject {
     }
 }
 
-trait BBIFile {
-    fn chroms(&self) -> &[bigtools::ChromInfo];
-}
-
-impl BBIFile for BigWigRead {
-    fn chroms(&self) -> &[bigtools::ChromInfo] {
-        match &self.bigwig {
-            BigWigRaw::File(b) => b.chroms(),
-            #[cfg(feature = "remote")]
-            BigWigRaw::Remote(b) => b.chroms(),
-            BigWigRaw::FileLike(b) => b.chroms(),
-        }
-    }
-}
-
-impl BBIFile for BigBedRead {
-    fn chroms(&self) -> &[bigtools::ChromInfo] {
-        match &self.bigbed {
-            BigBedRaw::File(b) => b.chroms(),
-            #[cfg(feature = "remote")]
-            BigBedRaw::Remote(b) => b.chroms(),
-            BigBedRaw::FileLike(b) => b.chroms(),
-        }
-    }
-}
-
-enum BigWigRaw {
-    File(BigWigReadRaw<CachedBBIFileRead<ReopenableFile>>),
+enum BBIReadRaw {
+    BigWigFile(BigWigReadRaw<CachedBBIFileRead<ReopenableFile>>),
     #[cfg(feature = "remote")]
-    Remote(BigWigReadRaw<CachedBBIFileRead<RemoteFile>>),
-    FileLike(BigWigReadRaw<CachedBBIFileRead<PyFileLikeObject>>),
+    BigWigRemote(BigWigReadRaw<CachedBBIFileRead<RemoteFile>>),
+    BigWigFileLike(BigWigReadRaw<CachedBBIFileRead<PyFileLikeObject>>),
+    BigBedFile(BigBedReadRaw<CachedBBIFileRead<ReopenableFile>>),
+    #[cfg(feature = "remote")]
+    BigBedRemote(BigBedReadRaw<CachedBBIFileRead<RemoteFile>>),
+    BigBedFileLike(BigBedReadRaw<CachedBBIFileRead<PyFileLikeObject>>),
 }
 
-/// This class is the interface for reading a bigWig.
+/// This class is the interface for reading a bigWig or bigBed.
 #[pyclass(module = "pybigtools")]
-struct BigWigRead {
-    bigwig: BigWigRaw,
+struct BBIRead {
+    bbi: BBIReadRaw,
 }
 
 #[pymethods]
-impl BigWigRead {
-    /// Returns the intervals of a given range on a chromosome. The result is an iterator of (int, int, float) in the format (start, end, value).
-    /// The intervals may not be contiguous if the values in the bigwig are not.  
+impl BBIRead {
+    /// Returns the autosql of this bbi file.
+    ///
+    /// For bigBeds, this comes directly from the autosql stored in the file.
+    /// For bigWigs, the autosql returned matches that of a bedGraph file.
+    ///
+    /// By default, the autosql is returned as a string. Passing `parse = true`
+    /// returns instead a dictionary of the format:
+    /// ```
+    /// {
+    ///   "name": <declared name>,
+    ///   "comment": <declaration coment>,
+    ///   "fields": [(<field name>, <field type>, <field comment>), ...],
+    /// }
+    /// ```
+    fn sql(&mut self, py: Python, parse: Option<bool>) -> PyResult<PyObject> {
+        let parse = parse.unwrap_or(false);
+        pub const BEDGRAPH: &str = r#"
+            table bedGraph
+            "bedGraph file"
+            (
+                string chrom;        "Reference sequence chromosome or scaffold"
+                uint   chromStart;   "Start position in chromosome"
+                uint   chromEnd;     "End position in chromosome"
+                float  value;        "Value for a given interval"
+            )
+            "#;
+        let schema = match &mut self.bbi {
+            BBIReadRaw::BigWigFile(_)
+            | BBIReadRaw::BigWigRemote(_)
+            | BBIReadRaw::BigWigFileLike(_) => BEDGRAPH.to_string(),
+            BBIReadRaw::BigBedFile(b) => b
+                .autosql()
+                .map_err(|e| PyErr::new::<exceptions::PyException, _>(format!("{}", e)))?,
+            BBIReadRaw::BigBedRemote(b) => b
+                .autosql()
+                .map_err(|e| PyErr::new::<exceptions::PyException, _>(format!("{}", e)))?,
+            BBIReadRaw::BigBedFileLike(b) => b
+                .autosql()
+                .map_err(|e| PyErr::new::<exceptions::PyException, _>(format!("{}", e)))?,
+        };
+        let obj = if parse {
+            let mut declarations = parse_autosql(&schema).map_err(|_| {
+                PyErr::new::<exceptions::PyException, _>("Unable to parse autosql.")
+            })?;
+            if declarations.len() > 1 {
+                return Err(PyErr::new::<exceptions::PyException, _>(
+                    "Unexpected extra declarations.",
+                ));
+            }
+            let declaration = declarations.pop();
+            match declaration {
+                None => PyDict::new(py).to_object(py),
+                Some(d) => {
+                    let fields = d
+                        .fields
+                        .iter()
+                        .map(|f| (&f.name, f.field_type.to_string(), &f.comment))
+                        .collect::<Vec<_>>()
+                        .to_object(py);
+                    [
+                        ("name", d.name.name.to_object(py)),
+                        ("comment", d.comment.to_object(py)),
+                        ("fields", fields),
+                    ]
+                    .into_py_dict(py)
+                    .to_object(py)
+                }
+            }
+        } else {
+            schema.to_object(py)
+        };
+        Ok(obj)
+    }
+
+    /// Returns the records of a given range on a chromosome.
+    ///
+    /// The result is an iterator of tuples. For bigWigs, these tuples are in
+    /// the format (start: int, end: int, value: float). For bigBeds, these
+    /// tuples are in the format (start: int, end: int, ...), where the "rest"
+    /// fields are split by whitespace.
+    ///
+    /// Missing values in bigWigs will results in non-contiguous records.
     ///
     /// The chrom argument is the name of the chromosome.  
-    /// The start and end arguments denote the range to get values for.  
-    ///  If end is not provided, it defaults to the length of the chromosome.  
-    ///  If start is not provided, it defaults to the beginning of the chromosome.  
-    ///
-    /// This returns an `IntervalIterator`.
-    fn intervals(
+    /// The start and end arguments denote the range to get values for.
+    ///  If end is not provided, it defaults to the length of the chromosome.
+    ///  If start is not provided, it defaults to the beginning of the chromosome.
+    fn records(
         &mut self,
+        py: Python<'_>,
         chrom: String,
         start: Option<u32>,
         end: Option<u32>,
-    ) -> PyResult<IntervalIterator> {
-        let (start, end) = start_end(self, &chrom, start, end)?;
-        match &self.bigwig {
-            BigWigRaw::File(b) => {
+    ) -> PyResult<PyObject> {
+        let (start, end) = start_end(&self.bbi, &chrom, start, end)?;
+        match &self.bbi {
+            BBIReadRaw::BigWigFile(b) => {
                 let b = b.reopen()?;
-                Ok(IntervalIterator {
+                Ok(BigWigIntervalIterator {
                     iter: Box::new(b.get_interval_move(&chrom, start, end).unwrap()),
-                })
+                }
+                .into_py(py))
             }
             #[cfg(feature = "remote")]
-            BigWigRaw::Remote(b) => {
+            BBIReadRaw::BigWigRemote(b) => {
                 let b = b.reopen()?;
-                Ok(IntervalIterator {
+                Ok(BigWigIntervalIterator {
                     iter: Box::new(b.get_interval_move(&chrom, start, end).unwrap()),
-                })
+                }
+                .into_py(py))
             }
-            BigWigRaw::FileLike(b) => {
+            BBIReadRaw::BigWigFileLike(b) => {
                 let b = b.reopen()?;
-                Ok(IntervalIterator {
+                Ok(BigWigIntervalIterator {
                     iter: Box::new(b.get_interval_move(&chrom, start, end).unwrap()),
-                })
+                }
+                .into_py(py))
+            }
+            BBIReadRaw::BigBedFile(b) => {
+                let b = b.reopen()?;
+                Ok(BigBedEntriesIterator {
+                    iter: Box::new(b.get_interval_move(&chrom, start, end).unwrap()),
+                }
+                .into_py(py))
+            }
+            #[cfg(feature = "remote")]
+            BBIReadRaw::BigBedRemote(b) => {
+                let b = b.reopen()?;
+                Ok(BigBedEntriesIterator {
+                    iter: Box::new(b.get_interval_move(&chrom, start, end).unwrap()),
+                }
+                .into_py(py))
+            }
+            BBIReadRaw::BigBedFileLike(b) => {
+                let b = b.reopen()?;
+                Ok(BigBedEntriesIterator {
+                    iter: Box::new(b.get_interval_move(&chrom, start, end).unwrap()),
+                }
+                .into_py(py))
             }
         }
     }
 
-    /// Returns the values of a given range on a chromosome. The result is an iterator of floats, of length (end - start).  
-    /// If a value does not exist in the bigwig for a specific base, it will be nan.  
+    /// Returns the values of a given range on a chromosome.
+    ///
+    /// For bigWigs, the result is an array of length (end - start).
+    /// If a value does not exist in the bigwig for a specific base, it will be nan.
+    ///
+    /// For bigBeds, the returned array instead represents a pileup of the count
+    /// of intervals overlapping each base.
     ///
     /// The chrom argument is the name of the chromosome.  
     /// The start and end arguments denote the range to get values for.  
@@ -284,6 +382,65 @@ impl BigWigRead {
             }
             Ok(Array::from(v))
         }
+        fn to_entry_array<I: Iterator<Item = Result<BedEntry, BBIReadError>>>(
+            start: usize,
+            end: usize,
+            iter: I,
+        ) -> Result<Array1<f64>, BBIReadError> {
+            use numpy::ndarray::Array;
+            let mut v = vec![0.0; end - start];
+            for interval in iter {
+                let interval = interval?;
+                let interval_start = (interval.start as usize) - start;
+                let interval_end = (interval.end as usize) - start;
+                for i in v[interval_start..interval_end].iter_mut() {
+                    *i += 1.0;
+                }
+            }
+            Ok(Array::from(v))
+        }
+        fn to_array_entry_bins<I: Iterator<Item = Result<BedEntry, BBIReadError>>>(
+            start: usize,
+            end: usize,
+            iter: I,
+            bins: usize,
+        ) -> Result<Array1<f64>, BBIReadError> {
+            use numpy::ndarray::Array;
+            let mut v = vec![0.0; bins];
+            let bin_size = (end - start) as f64 / bins as f64;
+            for interval in iter {
+                let interval = interval?;
+                let interval_start = (interval.start as usize) - start;
+                let interval_end = (interval.end as usize) - start;
+                let bin_start = ((interval_start as f64) / bin_size) as usize;
+                let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
+                for bin in bin_start..bin_end {
+                    v[bin] += 1.0;
+                }
+            }
+            Ok(Array::from(v))
+        }
+        fn to_entry_array_zoom<I: Iterator<Item = Result<ZoomRecord, BBIReadError>>>(
+            start: usize,
+            end: usize,
+            iter: I,
+            bins: usize,
+        ) -> Result<Array1<f64>, BBIReadError> {
+            use numpy::ndarray::Array;
+            let mut v = vec![0.0; bins];
+            let bin_size = (end - start) as f64 / bins as f64;
+            for interval in iter {
+                let interval = interval?;
+                let interval_start = (interval.start as usize).max(start) - start;
+                let interval_end = (interval.end as usize).min(end) - start;
+                let bin_start = ((interval_start as f64) / bin_size) as usize;
+                let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
+                for bin in bin_start..bin_end {
+                    v[bin] += interval.summary.total_items as f64;
+                }
+            }
+            Ok(Array::from(v))
+        }
 
         let summary = match summary.as_deref() {
             None => Summary::Mean,
@@ -296,103 +453,205 @@ impl BigWigRead {
                 )));
             }
         };
-        let (start, end) = start_end(self, &chrom, start, end)?;
-        macro_rules! to_array {
-            ($b:ident) => {{
-                match bins {
-                    Some(bins) if !exact.unwrap_or(false) => {
-                        let max_zoom_size = ((end - start) as f32 / (bins * 2) as f32) as u32;
-                        let zoom = ($b)
-                            .info()
-                            .zoom_headers
-                            .iter()
-                            .filter(|z| z.reduction_level <= max_zoom_size)
-                            .min_by_key(|z| max_zoom_size - z.reduction_level);
-                        match zoom {
-                            Some(zoom) => {
-                                let iter = ($b)
-                                    .get_zoom_interval(&chrom, start, end, zoom.reduction_level)
-                                    .map_err(|e| {
-                                        PyErr::new::<exceptions::PyException, _>(format!("{}", e))
-                                    })?;
-                                Python::with_gil(|py| {
-                                    Ok(to_array_zoom(
-                                        start as usize,
-                                        end as usize,
-                                        iter,
-                                        summary,
-                                        bins,
-                                    )
-                                    .map_err(|e| {
-                                        PyErr::new::<exceptions::PyException, _>(format!("{}", e))
-                                    })?
-                                    .into_pyarray(py)
-                                    .to_object(py))
-                                })
-                            }
-                            None => {
-                                let iter = ($b).get_interval(&chrom, start, end).map_err(|e| {
+        let (start, end) = start_end(&self.bbi, &chrom, start, end)?;
+        fn intervals_to_array<R: BBIFileRead>(
+            b: &mut BigWigReadRaw<R>,
+            chrom: &str,
+            start: u32,
+            end: u32,
+            bins: Option<usize>,
+            summary: Summary,
+            exact: Option<bool>,
+        ) -> PyResult<PyObject> {
+            match bins {
+                Some(bins) if !exact.unwrap_or(false) => {
+                    let max_zoom_size = ((end - start) as f32 / (bins * 2) as f32) as u32;
+                    let zoom = b
+                        .info()
+                        .zoom_headers
+                        .iter()
+                        .filter(|z| z.reduction_level <= max_zoom_size)
+                        .min_by_key(|z| max_zoom_size - z.reduction_level);
+                    match zoom {
+                        Some(zoom) => {
+                            let iter = b
+                                .get_zoom_interval(&chrom, start, end, zoom.reduction_level)
+                                .map_err(|e| {
                                     PyErr::new::<exceptions::PyException, _>(format!("{}", e))
                                 })?;
-                                Python::with_gil(|py| {
-                                    Ok(to_array_bins(
+                            Python::with_gil(|py| {
+                                Ok(
+                                    to_array_zoom(
                                         start as usize,
                                         end as usize,
                                         iter,
                                         summary,
                                         bins,
                                     )
-                                    .map_err(|e| {
-                                        PyErr::new::<exceptions::PyException, _>(format!("{}", e))
-                                    })?
-                                    .into_pyarray(py)
-                                    .to_object(py))
-                                })
-                            }
-                        }
-                    }
-                    Some(bins) => {
-                        let iter = ($b).get_interval(&chrom, start, end).map_err(|e| {
-                            PyErr::new::<exceptions::PyException, _>(format!("{}", e))
-                        })?;
-                        Python::with_gil(|py| {
-                            Ok(
-                                to_array_bins(start as usize, end as usize, iter, summary, bins)
                                     .map_err(|e| {
                                         PyErr::new::<exceptions::PyException, _>(format!("{}", e))
                                     })?
                                     .into_pyarray(py)
                                     .to_object(py),
-                            )
-                        })
+                                )
+                            })
+                        }
+                        None => {
+                            let iter = b.get_interval(&chrom, start, end).map_err(|e| {
+                                PyErr::new::<exceptions::PyException, _>(format!("{}", e))
+                            })?;
+                            Python::with_gil(|py| {
+                                Ok(
+                                    to_array_bins(
+                                        start as usize,
+                                        end as usize,
+                                        iter,
+                                        summary,
+                                        bins,
+                                    )
+                                    .map_err(|e| {
+                                        PyErr::new::<exceptions::PyException, _>(format!("{}", e))
+                                    })?
+                                    .into_pyarray(py)
+                                    .to_object(py),
+                                )
+                            })
+                        }
                     }
-                    _ => {
-                        let iter = ($b).get_interval(&chrom, start, end).map_err(|e| {
-                            PyErr::new::<exceptions::PyException, _>(format!("{}", e))
-                        })?;
-                        Python::with_gil(|py| {
-                            Ok(to_array(start as usize, end as usize, iter)
+                }
+                Some(bins) => {
+                    let iter = b
+                        .get_interval(&chrom, start, end)
+                        .map_err(|e| PyErr::new::<exceptions::PyException, _>(format!("{}", e)))?;
+                    Python::with_gil(|py| {
+                        Ok(
+                            to_array_bins(start as usize, end as usize, iter, summary, bins)
                                 .map_err(|e| {
                                     PyErr::new::<exceptions::PyException, _>(format!("{}", e))
                                 })?
                                 .into_pyarray(py)
-                                .to_object(py))
-                        })
+                                .to_object(py),
+                        )
+                    })
+                }
+                _ => {
+                    let iter = b
+                        .get_interval(&chrom, start, end)
+                        .map_err(|e| PyErr::new::<exceptions::PyException, _>(format!("{}", e)))?;
+                    Python::with_gil(|py| {
+                        Ok(to_array(start as usize, end as usize, iter)
+                            .map_err(|e| {
+                                PyErr::new::<exceptions::PyException, _>(format!("{}", e))
+                            })?
+                            .into_pyarray(py)
+                            .to_object(py))
+                    })
+                }
+            }
+        }
+        fn entries_to_array<R: BBIFileRead>(
+            b: &mut BigBedReadRaw<R>,
+            chrom: &str,
+            start: u32,
+            end: u32,
+            bins: Option<usize>,
+            exact: Option<bool>,
+        ) -> PyResult<PyObject> {
+            match bins {
+                Some(bins) if !exact.unwrap_or(false) => {
+                    let max_zoom_size = ((end - start) as f32 / (bins * 2) as f32) as u32;
+                    let zoom = b
+                        .info()
+                        .zoom_headers
+                        .iter()
+                        .filter(|z| z.reduction_level <= max_zoom_size)
+                        .min_by_key(|z| max_zoom_size - z.reduction_level);
+                    match zoom {
+                        Some(zoom) => {
+                            let iter = b
+                                .get_zoom_interval(&chrom, start, end, zoom.reduction_level)
+                                .map_err(|e| {
+                                    PyErr::new::<exceptions::PyException, _>(format!("{}", e))
+                                })?;
+                            Python::with_gil(|py| {
+                                Ok(
+                                    to_entry_array_zoom(start as usize, end as usize, iter, bins)
+                                        .map_err(|e| {
+                                            PyErr::new::<exceptions::PyException, _>(format!(
+                                                "{}",
+                                                e
+                                            ))
+                                        })?
+                                        .into_pyarray(py)
+                                        .to_object(py),
+                                )
+                            })
+                        }
+                        None => {
+                            let iter = b.get_interval(&chrom, start, end).map_err(|e| {
+                                PyErr::new::<exceptions::PyException, _>(format!("{}", e))
+                            })?;
+                            Python::with_gil(|py| {
+                                Ok(
+                                    to_array_entry_bins(start as usize, end as usize, iter, bins)
+                                        .map_err(|e| {
+                                            PyErr::new::<exceptions::PyException, _>(format!(
+                                                "{}",
+                                                e
+                                            ))
+                                        })?
+                                        .into_pyarray(py)
+                                        .to_object(py),
+                                )
+                            })
+                        }
                     }
                 }
-            }};
+                Some(bins) => {
+                    let iter = b
+                        .get_interval(&chrom, start, end)
+                        .map_err(|e| PyErr::new::<exceptions::PyException, _>(format!("{}", e)))?;
+                    Python::with_gil(|py| {
+                        Ok(
+                            to_array_entry_bins(start as usize, end as usize, iter, bins)
+                                .map_err(|e| {
+                                    PyErr::new::<exceptions::PyException, _>(format!("{}", e))
+                                })?
+                                .into_pyarray(py)
+                                .to_object(py),
+                        )
+                    })
+                }
+                _ => {
+                    let iter = b
+                        .get_interval(&chrom, start, end)
+                        .map_err(|e| PyErr::new::<exceptions::PyException, _>(format!("{}", e)))?;
+                    Python::with_gil(|py| {
+                        Ok(to_entry_array(start as usize, end as usize, iter)
+                            .map_err(|e| {
+                                PyErr::new::<exceptions::PyException, _>(format!("{}", e))
+                            })?
+                            .into_pyarray(py)
+                            .to_object(py))
+                    })
+                }
+            }
         }
-        match &mut self.bigwig {
-            BigWigRaw::File(b) => {
-                to_array!(b)
+        match &mut self.bbi {
+            BBIReadRaw::BigWigFile(b) => {
+                intervals_to_array(b, &chrom, start, end, bins, summary, exact)
             }
             #[cfg(feature = "remote")]
-            BigWigRaw::Remote(b) => {
-                to_array!(b)
+            BBIReadRaw::BigWigRemote(b) => {
+                intervals_to_array(b, &chrom, start, end, bins, summary, exact)
             }
-            BigWigRaw::FileLike(b) => {
-                to_array!(b)
+            BBIReadRaw::BigWigFileLike(b) => {
+                intervals_to_array(b, &chrom, start, end, bins, summary, exact)
             }
+            BBIReadRaw::BigBedFile(b) => entries_to_array(b, &chrom, start, end, bins, exact),
+            #[cfg(feature = "remote")]
+            BBIReadRaw::BigBedRemote(b) => entries_to_array(b, &chrom, start, end, bins, exact),
+            BBIReadRaw::BigBedFileLike(b) => entries_to_array(b, &chrom, start, end, bins, exact),
         }
     }
 
@@ -402,63 +661,37 @@ impl BigWigRead {
     ///  If it is None, then all chroms will be returned.  
     ///  If it is a String, then the length of that chromosome will be returned.  
     ///  If the chromosome doesn't exist, nothing will be returned.  
-    fn chroms(&mut self, py: Python, chrom: Option<String>) -> PyResult<Option<PyObject>> {
-        match &self.bigwig {
-            BigWigRaw::File(b) => {
-                let val = match chrom {
-                    Some(chrom) => b
-                        .chroms()
+    fn chroms(&mut self, py: Python, chrom: Option<String>) -> Option<PyObject> {
+        fn get_chrom_obj<B: bigtools::BBIRead>(
+            b: &B,
+            py: Python,
+            chrom: Option<String>,
+        ) -> Option<PyObject> {
+            match chrom {
+                Some(chrom) => b
+                    .chroms()
+                    .into_iter()
+                    .find(|c| c.name == chrom)
+                    .map(|c| c.length)
+                    .map(|c| c.to_object(py)),
+                None => Some(
+                    b.chroms()
                         .into_iter()
-                        .find(|c| c.name == chrom)
-                        .map(|c| c.length)
-                        .map(|c| c.to_object(py)),
-                    None => Some(
-                        b.chroms()
-                            .into_iter()
-                            .map(|c| (c.name.clone(), c.length))
-                            .into_py_dict(py)
-                            .into(),
-                    ),
-                };
-                Ok(val)
+                        .map(|c| (c.name.clone(), c.length))
+                        .into_py_dict(py)
+                        .into(),
+                ),
             }
+        }
+        match &self.bbi {
+            BBIReadRaw::BigWigFile(b) => get_chrom_obj(b, py, chrom),
             #[cfg(feature = "remote")]
-            BigWigRaw::Remote(b) => {
-                let val = match chrom {
-                    Some(chrom) => b
-                        .chroms()
-                        .into_iter()
-                        .find(|c| c.name == chrom)
-                        .map(|c| c.length)
-                        .map(|c| c.to_object(py)),
-                    None => Some(
-                        b.chroms()
-                            .into_iter()
-                            .map(|c| (c.name.clone(), c.length))
-                            .into_py_dict(py)
-                            .into(),
-                    ),
-                };
-                Ok(val)
-            }
-            BigWigRaw::FileLike(b) => {
-                let val = match chrom {
-                    Some(chrom) => b
-                        .chroms()
-                        .into_iter()
-                        .find(|c| c.name == chrom)
-                        .map(|c| c.length)
-                        .map(|c| c.to_object(py)),
-                    None => Some(
-                        b.chroms()
-                            .into_iter()
-                            .map(|c| (c.name.clone(), c.length))
-                            .into_py_dict(py)
-                            .into(),
-                    ),
-                };
-                Ok(val)
-            }
+            BBIReadRaw::BigWigRemote(b) => get_chrom_obj(b, py, chrom),
+            BBIReadRaw::BigWigFileLike(b) => get_chrom_obj(b, py, chrom),
+            BBIReadRaw::BigBedFile(b) => get_chrom_obj(b, py, chrom),
+            #[cfg(feature = "remote")]
+            BBIReadRaw::BigBedRemote(b) => get_chrom_obj(b, py, chrom),
+            BBIReadRaw::BigBedFileLike(b) => get_chrom_obj(b, py, chrom),
         }
     }
 }
@@ -467,13 +700,13 @@ impl BigWigRead {
 /// It returns only values that exist in the bigWig, skipping
 /// any missing intervals.
 #[pyclass(module = "pybigtools")]
-struct IntervalIterator {
+struct BigWigIntervalIterator {
     iter: Box<dyn Iterator<Item = Result<Value, BBIReadError>> + Send>,
 }
 
 #[pymethods]
-impl IntervalIterator {
-    fn __iter__(slf: PyRefMut<Self>) -> PyResult<Py<IntervalIterator>> {
+impl BigWigIntervalIterator {
+    fn __iter__(slf: PyRefMut<Self>) -> PyResult<Py<BigWigIntervalIterator>> {
         Ok(slf.into())
     }
 
@@ -483,6 +716,27 @@ impl IntervalIterator {
             .transpose()
             .map(|o| o.map(|v| (v.start, v.end, v.value)))
             .map_err(|e| PyErr::new::<exceptions::PyException, _>(format!("{}", e)))
+    }
+}
+
+/// This class is an interator for the entries in a bigBed file.
+#[pyclass(module = "pybigtools")]
+struct BigBedEntriesIterator {
+    iter: Box<dyn Iterator<Item = Result<BedEntry, BBIReadError>> + Send>,
+}
+
+#[pymethods]
+impl BigBedEntriesIterator {
+    fn __iter__(slf: PyRefMut<Self>) -> PyResult<Py<BigBedEntriesIterator>> {
+        Ok(slf.into())
+    }
+
+    fn __next__(mut slf: PyRefMut<Self>) -> PyResult<Option<BedEntryTuple>> {
+        Ok(slf
+            .iter
+            .next()
+            .map(|e| e.unwrap())
+            .map(|e| (e.start, e.end, e.rest)))
     }
 }
 
@@ -622,144 +876,6 @@ impl BigWigWrite {
     fn close(&mut self) -> PyResult<()> {
         self.bigwig.take();
         Ok(())
-    }
-}
-
-enum BigBedRaw {
-    File(BigBedReadRaw<CachedBBIFileRead<ReopenableFile>>),
-    #[cfg(feature = "remote")]
-    Remote(BigBedReadRaw<CachedBBIFileRead<RemoteFile>>),
-    FileLike(BigBedReadRaw<CachedBBIFileRead<PyFileLikeObject>>),
-}
-
-/// This class is the interface for reading a bigBed.
-#[pyclass(module = "pybigtools")]
-struct BigBedRead {
-    bigbed: BigBedRaw,
-}
-
-#[pymethods]
-impl BigBedRead {
-    /// Returns the entries of a given range on a chromosome. The result is an iterator of (int, int, String) in the format (start, end, rest).  
-    /// The entries may not be contiguous if the values in the bigbed are not.  
-    /// The chrom argument is the name of the chromosome.  
-    /// The start and end arguments denote the range to get values for.  
-    ///  If end is not provided, it defaults to the length of the chromosome.  
-    ///  If start is not provided, it defaults to the beginning of the chromosome.  
-    ///
-    /// This returns an `EntriesIterator`.  
-    fn entries(
-        &mut self,
-        chrom: String,
-        start: Option<u32>,
-        end: Option<u32>,
-    ) -> PyResult<EntriesIterator> {
-        let (start, end) = start_end(self, &chrom, start, end)?;
-        match &mut self.bigbed {
-            BigBedRaw::File(b) => {
-                let b = b.reopen()?;
-                Ok(EntriesIterator {
-                    iter: Box::new(b.get_interval_move(&chrom, start, end).unwrap()),
-                })
-            }
-            #[cfg(feature = "remote")]
-            BigBedRaw::Remote(b) => {
-                let b = b.reopen()?;
-                Ok(EntriesIterator {
-                    iter: Box::new(b.get_interval_move(&chrom, start, end).unwrap()),
-                })
-            }
-            BigBedRaw::FileLike(b) => {
-                let b = b.reopen()?;
-                Ok(EntriesIterator {
-                    iter: Box::new(b.get_interval_move(&chrom, start, end).unwrap()),
-                })
-            }
-        }
-    }
-
-    /// Returns the chromosomes in a bigwig, and their lengths.  
-    /// The chroms argument can be either String or None. If it is None, then all chroms will be returned. If it is a String, then the length of that chromosome will be returned.  
-    ///  If the chromosome doesn't exist, nothing will be returned.  
-    fn chroms(&mut self, py: Python, chrom: Option<String>) -> PyResult<Option<PyObject>> {
-        match &self.bigbed {
-            BigBedRaw::File(b) => {
-                let val = match chrom {
-                    Some(chrom) => b
-                        .chroms()
-                        .into_iter()
-                        .find(|c| c.name == chrom)
-                        .map(|c| c.length)
-                        .map(|c| c.to_object(py)),
-                    None => Some(
-                        b.chroms()
-                            .into_iter()
-                            .map(|c| (c.name.clone(), c.length))
-                            .into_py_dict(py)
-                            .into(),
-                    ),
-                };
-                Ok(val)
-            }
-            #[cfg(feature = "remote")]
-            BigBedRaw::Remote(b) => {
-                let val = match chrom {
-                    Some(chrom) => b
-                        .chroms()
-                        .into_iter()
-                        .find(|c| c.name == chrom)
-                        .map(|c| c.length)
-                        .map(|c| c.to_object(py)),
-                    None => Some(
-                        b.chroms()
-                            .into_iter()
-                            .map(|c| (c.name.clone(), c.length))
-                            .into_py_dict(py)
-                            .into(),
-                    ),
-                };
-                Ok(val)
-            }
-            BigBedRaw::FileLike(b) => {
-                let val = match chrom {
-                    Some(chrom) => b
-                        .chroms()
-                        .into_iter()
-                        .find(|c| c.name == chrom)
-                        .map(|c| c.length)
-                        .map(|c| c.to_object(py)),
-                    None => Some(
-                        b.chroms()
-                            .into_iter()
-                            .map(|c| (c.name.clone(), c.length))
-                            .into_py_dict(py)
-                            .into(),
-                    ),
-                };
-                Ok(val)
-            }
-        }
-    }
-}
-
-/// This class is an interator for the entries in a bigBed file.
-#[pyclass(module = "pybigtools")]
-struct EntriesIterator {
-    iter: Box<dyn Iterator<Item = Result<BedEntry, BBIReadError>> + Send>,
-}
-
-#[pymethods]
-impl EntriesIterator {
-    fn __iter__(slf: PyRefMut<Self>) -> PyResult<Py<EntriesIterator>> {
-        Ok(slf.into())
-    }
-
-    fn __next__(mut slf: PyRefMut<Self>) -> PyResult<Option<BedEntryTuple>> {
-        Ok(slf
-            .iter
-            .next()
-            .map(|e| e.unwrap())
-            .map(|e| (e.start, e.end, e.rest)))
     }
 }
 
@@ -966,9 +1082,8 @@ impl BigWigAverageOverBedEntriesIterator {
 ///
 /// This returns one of the following:  
 /// - `BigWigWrite`
-/// - `BigWigRead`
 /// - `BigBedWrite`
-/// - `BigBedRead`
+/// - `BBIRead`
 #[pyfunction]
 fn open(py: Python, path_url_or_file_like: PyObject, mode: Option<String>) -> PyResult<PyObject> {
     let iswrite = match &mode {
@@ -1000,13 +1115,13 @@ fn open(py: Python, path_url_or_file_like: PyObject, mode: Option<String>) -> Py
         ))),
     };
     let read = match BigWigReadRaw::open(file_like.clone()) {
-        Ok(bwr) => BigWigRead {
-            bigwig: BigWigRaw::FileLike(bwr.cached()),
+        Ok(bwr) => BBIRead {
+            bbi: BBIReadRaw::BigWigFileLike(bwr.cached()),
         }
         .into_py(py),
         Err(_) => match BigBedReadRaw::open(file_like) {
-            Ok(bbr) => BigBedRead {
-                bigbed: BigBedRaw::FileLike(bbr.cached()),
+            Ok(bbr) => BBIRead {
+                bbi: BBIReadRaw::BigBedFileLike(bbr.cached()),
             }
             .into_py(py),
             Err(e) => {
@@ -1071,8 +1186,8 @@ fn open_path_or_url(
             "bw" | "bigWig" | "bigwig" => {
                 if isfile {
                     match BigWigReadRaw::open_file(&path_url_or_file_like) {
-                        Ok(bwr) => BigWigRead {
-                            bigwig: BigWigRaw::File(bwr.cached()),
+                        Ok(bwr) => BBIRead {
+                            bbi: BBIReadRaw::BigWigFile(bwr.cached()),
                         }
                         .into_py(py),
                         Err(_) => {
@@ -1084,8 +1199,8 @@ fn open_path_or_url(
                 } else {
                     #[cfg(feature = "remote")]
                     match BigWigReadRaw::open(RemoteFile::new(&path_url_or_file_like)) {
-                        Ok(bwr) => BigWigRead {
-                            bigwig: BigWigRaw::Remote(bwr.cached()),
+                        Ok(bwr) => BBIRead {
+                            bbi: BBIReadRaw::BigWigRemote(bwr.cached()),
                         }
                         .into_py(py),
                         Err(_) => {
@@ -1106,8 +1221,8 @@ fn open_path_or_url(
             "bb" | "bigBed" | "bigbed" => {
                 if isfile {
                     match BigBedReadRaw::open_file(&path_url_or_file_like) {
-                        Ok(bwr) => BigBedRead {
-                            bigbed: BigBedRaw::File(bwr.cached()),
+                        Ok(bwr) => BBIRead {
+                            bbi: BBIReadRaw::BigBedFile(bwr.cached()),
                         }
                         .into_py(py),
                         Err(_) => {
@@ -1119,8 +1234,8 @@ fn open_path_or_url(
                 } else {
                     #[cfg(feature = "remote")]
                     match BigBedReadRaw::open(RemoteFile::new(&path_url_or_file_like)) {
-                        Ok(bwr) => BigBedRead {
-                            bigbed: BigBedRaw::Remote(bwr.cached()),
+                        Ok(bwr) => BBIRead {
+                            bbi: BBIReadRaw::BigBedRemote(bwr.cached()),
                         }
                         .into_py(py),
                         Err(_) => {
@@ -1275,12 +1390,10 @@ fn pybigtools(_py: Python, m: &PyModule) -> PyResult<()> {
 
     m.add_class::<BigWigWrite>()?;
     m.add_class::<BigBedWrite>()?;
-    m.add_class::<BigWigRead>()?;
-    m.add_class::<BigBedRead>()?;
+    m.add_class::<BBIRead>()?;
 
-    m.add_class::<IntervalIterator>()?;
-
-    m.add_class::<EntriesIterator>()?;
+    m.add_class::<BigWigIntervalIterator>()?;
+    m.add_class::<BigBedEntriesIterator>()?;
 
     Ok(())
 }

--- a/pybigtools/src/lib.rs
+++ b/pybigtools/src/lib.rs
@@ -179,127 +179,114 @@ fn intervals_to_array<R: BBIFileRead>(
     } else {
         None
     };
+    let arr = match (bins, arr) {
+        (_, Some(arr)) => arr,
+        (Some(bins), None) => PyArray1::from_vec(py, vec![missing; bins]).to_object(py),
+        (None, None) => PyArray1::from_vec(py, vec![missing; (end - start) as usize]).to_object(py),
+    };
+    let v: &PyArray1<f64> = arr.downcast::<PyArray1<f64>>(py).map_err(|_| {
+        PyErr::new::<exceptions::PyException, _>(
+            "`arr` option must be a one-dimensional numpy array, if passed.",
+        )
+    })?;
     let (intervals_start, intervals_end) = (start.max(0) as u32, end.min(length) as u32);
-    match bins {
+    let bin_size = match bins {
         Some(bins) => {
-            let arr = match arr {
-                Some(v) => v,
-                None => PyArray1::from_vec(py, vec![missing; bins]).to_object(py),
-            };
-            let v: &PyArray1<f64> = arr.downcast::<PyArray1<f64>>(py).map_err(|_| {
-                PyErr::new::<exceptions::PyException, _>(
-                    "`arr` option must be a one-dimensional numpy array, if passed.",
-                )
-            })?;
-            {
-                let mut array = v.readwrite();
-
-                match zoom {
-                    Some(zoom) => {
-                        let iter = b
-                            .get_zoom_interval(
-                                &chrom,
-                                intervals_start,
-                                intervals_end,
-                                zoom.reduction_level,
-                            )
-                            .convert_err()?;
-                        to_array_zoom(
-                            start,
-                            end,
-                            iter,
-                            summary,
-                            bins,
-                            missing,
-                            array.as_array_mut(),
-                        )
-                        .convert_err()?;
-                    }
-                    None => {
-                        let iter = b
-                            .get_interval(&chrom, intervals_start, intervals_end)
-                            .convert_err()?;
-                        to_array_bins(
-                            start,
-                            end,
-                            iter,
-                            summary,
-                            bins,
-                            missing,
-                            array.as_array_mut(),
-                        )
-                        .convert_err()?;
-                    }
-                };
-
-                let mut array: ArrayViewMut<'_, f64, numpy::Ix1> = array.as_array_mut();
-
-                let bin_size = (end - start) as f64 / bins as f64;
-                if start < 0 {
-                    let bin_start = 0;
-                    let interval_end = 0 - start;
-                    let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
-                    for i in bin_start..bin_end {
-                        array[i] = oob;
-                    }
-                }
-                if end >= length {
-                    let interval_start = (length as i32) - start;
-                    let interval_end = end - start;
-                    let bin_start = ((interval_start as f64) / bin_size) as usize;
-                    let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
-                    assert_eq!(bin_end, array.len() - 1);
-                    for i in bin_start..bin_end {
-                        array[i] = oob;
-                    }
-                }
+            if v.len() != bins {
+                return Err(PyErr::new::<exceptions::PyException, _>(format!(
+                    "`arr` does not the expected size (expected `{}`, found `{}`), if passed.",
+                    bins,
+                    v.len(),
+                )));
             }
-            Ok(arr)
+
+            let mut array = v.readwrite();
+
+            match zoom {
+                Some(zoom) => {
+                    let iter = b
+                        .get_zoom_interval(
+                            &chrom,
+                            intervals_start,
+                            intervals_end,
+                            zoom.reduction_level,
+                        )
+                        .convert_err()?;
+                    to_array_zoom(
+                        start,
+                        end,
+                        iter,
+                        summary,
+                        bins,
+                        missing,
+                        array.as_array_mut(),
+                    )
+                    .convert_err()?;
+                }
+                None => {
+                    let iter = b
+                        .get_interval(&chrom, intervals_start, intervals_end)
+                        .convert_err()?;
+                    to_array_bins(
+                        start,
+                        end,
+                        iter,
+                        summary,
+                        bins,
+                        missing,
+                        array.as_array_mut(),
+                    )
+                    .convert_err()?;
+                }
+            };
+
+            (end - start) as f64 / bins as f64
         }
         _ => {
-            let arr = match arr {
-                Some(v) => v,
-                None => PyArray1::from_vec(py, vec![missing; (end - start) as usize]).to_object(py),
-            };
-            let v: &PyArray1<f64> = arr.downcast::<PyArray1<f64>>(py).map_err(|_| {
-                PyErr::new::<exceptions::PyException, _>(
-                    "`arr` option must be a one-dimensional numpy array, if passed.",
-                )
-            })?;
-
-            {
-                let mut array = v.readwrite();
-
-                let iter = b
-                    .get_interval(&chrom, intervals_start, intervals_end)
-                    .convert_err()?;
-                to_array(start, end, iter, array.as_array_mut()).convert_err()?;
-
-                let mut array: ArrayViewMut<'_, f64, numpy::Ix1> = array.as_array_mut();
-
-                let bin_size = (end - start) as f64;
-                if start < 0 {
-                    let bin_start = 0;
-                    let interval_end = 0 - start;
-                    let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
-                    for i in bin_start..bin_end {
-                        array[i] = oob;
-                    }
-                }
-                if end >= length {
-                    let interval_start = (length as i32) - start;
-                    let interval_end = end - start;
-                    let bin_start = ((interval_start as f64) / bin_size) as usize;
-                    let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
-                    assert_eq!(bin_end, array.len() - 1);
-                    for i in bin_start..bin_end {
-                        array[i] = oob;
-                    }
-                }
+            if v.len() != (end - start) as usize {
+                return Err(PyErr::new::<exceptions::PyException, _>(format!(
+                    "`arr` does not the expected size (expected `{}`, found `{}`), if passed.",
+                    (end - start) as usize,
+                    v.len(),
+                )));
             }
-            Ok(arr)
+
+            let mut array = v.readwrite();
+
+            let iter = b
+                .get_interval(&chrom, intervals_start, intervals_end)
+                .convert_err()?;
+            to_array(start, end, iter, missing, array.as_array_mut()).convert_err()?;
+
+            (end - start) as f64
+        }
+    };
+
+    {
+        let mut array = v.readwrite();
+        let mut array: ArrayViewMut<'_, f64, numpy::Ix1> = array.as_array_mut();
+
+        if start < 0 {
+            let bin_start = 0;
+            let interval_end = 0 - start;
+            let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
+            for i in bin_start..bin_end {
+                array[i] = oob;
+            }
+        }
+        if end >= length {
+            let interval_start = (length as i32) - start;
+            let interval_end = end - start;
+            let bin_start = ((interval_start as f64) / bin_size) as usize;
+            let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
+            assert_eq!(bin_end, array.len() - 1);
+            for i in bin_start..bin_end {
+                array[i] = oob;
+            }
         }
     }
+
+    Ok(arr)
 }
 fn entries_to_array<R: BBIFileRead>(
     py: Python<'_>,
@@ -327,119 +314,125 @@ fn entries_to_array<R: BBIFileRead>(
     } else {
         None
     };
+    let arr = match (bins, arr) {
+        (_, Some(arr)) => arr,
+        (Some(bins), None) => PyArray1::from_vec(py, vec![missing; bins]).to_object(py),
+        (None, None) => PyArray1::from_vec(py, vec![missing; (end - start) as usize]).to_object(py),
+    };
+    let v: &PyArray1<f64> = arr.downcast::<PyArray1<f64>>(py).map_err(|_| {
+        PyErr::new::<exceptions::PyException, _>(
+            "`arr` option must be a one-dimensional numpy array, if passed.",
+        )
+    })?;
     let (intervals_start, intervals_end) = (start.max(0) as u32, end.min(length) as u32);
-    match bins {
+    let bin_size = match bins {
         Some(bins) => {
-            let arr = match arr {
-                Some(v) => v,
-                None => PyArray1::from_vec(py, vec![missing; bins]).to_object(py),
-            };
-            let v: &PyArray1<f64> = arr.downcast::<PyArray1<f64>>(py).map_err(|_| {
-                PyErr::new::<exceptions::PyException, _>(
-                    "`arr` option must be a one-dimensional numpy array, if passed.",
-                )
-            })?;
-            {
-                let mut array = v.readwrite();
-
-                match zoom {
-                    Some(zoom) => {
-                        let iter = b
-                            .get_zoom_interval(
-                                &chrom,
-                                intervals_start,
-                                intervals_end,
-                                zoom.reduction_level,
-                            )
-                            .convert_err()?;
-                        to_entry_array_zoom(start, end, iter, summary, bins, array.as_array_mut())
-                            .convert_err()?;
-                    }
-                    None => {
-                        let iter = b
-                            .get_interval(&chrom, intervals_start, intervals_end)
-                            .convert_err()?;
-                        to_entry_array_bins(start, end, iter, summary, bins, array.as_array_mut())
-                            .convert_err()?;
-                    }
-                };
-
-                let mut array: ArrayViewMut<'_, f64, numpy::Ix1> = array.as_array_mut();
-
-                let bin_size = (end - start) as f64 / bins as f64;
-                if start < 0 {
-                    let bin_start = 0;
-                    let interval_end = 0 - start;
-                    let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
-                    for i in bin_start..bin_end {
-                        array[i] = oob;
-                    }
-                }
-                if end >= length {
-                    let interval_start = (length as i32) - start;
-                    let interval_end = end - start;
-                    let bin_start = ((interval_start as f64) / bin_size) as usize;
-                    let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
-                    assert_eq!(bin_end, array.len() - 1);
-                    for i in bin_start..bin_end {
-                        array[i] = oob;
-                    }
-                }
+            if v.len() != bins {
+                return Err(PyErr::new::<exceptions::PyException, _>(format!(
+                    "`arr` does not the expected size (expected `{}`, found `{}`), if passed.",
+                    bins,
+                    v.len(),
+                )));
             }
-            Ok(arr)
+
+            let mut array = v.readwrite();
+
+            match zoom {
+                Some(zoom) => {
+                    let iter = b
+                        .get_zoom_interval(
+                            &chrom,
+                            intervals_start,
+                            intervals_end,
+                            zoom.reduction_level,
+                        )
+                        .convert_err()?;
+                    to_entry_array_zoom(
+                        start,
+                        end,
+                        iter,
+                        summary,
+                        bins,
+                        missing,
+                        array.as_array_mut(),
+                    )
+                    .convert_err()?;
+                }
+                None => {
+                    let iter = b
+                        .get_interval(&chrom, intervals_start, intervals_end)
+                        .convert_err()?;
+                    to_entry_array_bins(
+                        start,
+                        end,
+                        iter,
+                        summary,
+                        bins,
+                        missing,
+                        array.as_array_mut(),
+                    )
+                    .convert_err()?;
+                }
+            };
+
+            (end - start) as f64 / bins as f64
         }
         _ => {
-            let arr = match arr {
-                Some(v) => v,
-                None => PyArray1::from_vec(py, vec![missing; (end - start) as usize]).to_object(py),
-            };
-            let v: &PyArray1<f64> = arr.downcast::<PyArray1<f64>>(py).map_err(|_| {
-                PyErr::new::<exceptions::PyException, _>(
-                    "`arr` option must be a one-dimensional numpy array, if passed.",
-                )
-            })?;
-
-            {
-                let mut array = v.readwrite();
-
-                let iter = b
-                    .get_interval(&chrom, intervals_start, intervals_end)
-                    .convert_err()?;
-                to_entry_array(start, end, iter, array.as_array_mut()).convert_err()?;
-
-                let mut array: ArrayViewMut<'_, f64, numpy::Ix1> = array.as_array_mut();
-
-                let bin_size = (end - start) as f64;
-                if start < 0 {
-                    let bin_start = 0;
-                    let interval_end = 0 - start;
-                    let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
-                    for i in bin_start..bin_end {
-                        array[i] = oob;
-                    }
-                }
-                if end >= length {
-                    let interval_start = (length as i32) - start;
-                    let interval_end = end - start;
-                    let bin_start = ((interval_start as f64) / bin_size) as usize;
-                    let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
-                    assert_eq!(bin_end, array.len() - 1);
-                    for i in bin_start..bin_end {
-                        array[i] = oob;
-                    }
-                }
+            if v.len() != (end - start) as usize {
+                return Err(PyErr::new::<exceptions::PyException, _>(format!(
+                    "`arr` does not the expected size (expected `{}`, found `{}`), if passed.",
+                    (end - start) as usize,
+                    v.len(),
+                )));
             }
-            Ok(arr)
+
+            let mut array = v.readwrite();
+
+            let iter = b
+                .get_interval(&chrom, intervals_start, intervals_end)
+                .convert_err()?;
+            to_entry_array(start, end, iter, missing, array.as_array_mut()).convert_err()?;
+
+            (end - start) as f64
+        }
+    };
+
+    {
+        let mut array = v.readwrite();
+        let mut array: ArrayViewMut<'_, f64, numpy::Ix1> = array.as_array_mut();
+
+        if start < 0 {
+            let bin_start = 0;
+            let interval_end = 0 - start;
+            let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
+            for i in bin_start..bin_end {
+                array[i] = oob;
+            }
+        }
+        if end >= length {
+            let interval_start = (length as i32) - start;
+            let interval_end = end - start;
+            let bin_start = ((interval_start as f64) / bin_size) as usize;
+            let bin_end = ((interval_end as f64) / bin_size).ceil() as usize;
+            assert_eq!(bin_end, array.len() - 1);
+            for i in bin_start..bin_end {
+                array[i] = oob;
+            }
         }
     }
+
+    Ok(arr)
 }
+
 fn to_array<I: Iterator<Item = Result<Value, BBIReadError>>>(
     start: i32,
     end: i32,
     iter: I,
+    missing: f64,
     mut v: ArrayViewMut<'_, f64, numpy::Ix1>,
 ) -> Result<(), BBIReadError> {
     assert_eq!(v.len(), (end - start) as usize);
+    v.fill(missing);
     for interval in iter {
         let interval = interval?;
         let interval_start = ((interval.start as i32) - start) as usize;
@@ -460,6 +453,7 @@ fn to_array_bins<I: Iterator<Item = Result<Value, BBIReadError>>>(
     mut v: ArrayViewMut<'_, f64, numpy::Ix1>,
 ) -> Result<(), BBIReadError> {
     assert_eq!(v.len(), bins);
+    v.fill(missing);
 
     let mut bin_data: VecDeque<(usize, i32, i32, Option<f64>)> = VecDeque::new();
     let bin_size = (end - start) as f64 / bins as f64;
@@ -565,6 +559,7 @@ fn to_array_zoom<I: Iterator<Item = Result<ZoomRecord, BBIReadError>>>(
     mut v: ArrayViewMut<'_, f64, numpy::Ix1>,
 ) -> Result<(), BBIReadError> {
     assert_eq!(v.len(), bins);
+    v.fill(missing);
 
     let mut bin_data: VecDeque<(usize, i32, i32, Option<f64>)> = VecDeque::new();
     let bin_size = (end - start) as f64 / bins as f64;
@@ -675,9 +670,11 @@ fn to_entry_array<I: Iterator<Item = Result<BedEntry, BBIReadError>>>(
     start: i32,
     end: i32,
     iter: I,
+    missing: f64,
     mut v: ArrayViewMut<'_, f64, numpy::Ix1>,
 ) -> Result<(), BBIReadError> {
     assert_eq!(v.len(), (end - start) as usize);
+    v.fill(missing);
     for interval in iter {
         let interval = interval?;
         let interval_start = ((interval.start as i32) - start) as usize;
@@ -694,9 +691,11 @@ fn to_entry_array_bins<I: Iterator<Item = Result<BedEntry, BBIReadError>>>(
     iter: I,
     summary: Summary,
     bins: usize,
+    missing: f64,
     mut v: ArrayViewMut<'_, f64, numpy::Ix1>,
 ) -> Result<(), BBIReadError> {
     assert_eq!(v.len(), bins);
+    v.fill(missing);
 
     let mut bin_data: VecDeque<(usize, i32, i32, Vec<f64>)> = VecDeque::new();
     let bin_size = (end - start) as f64 / bins as f64;
@@ -718,14 +717,14 @@ fn to_entry_array_bins<I: Iterator<Item = Result<BedEntry, BBIReadError>>>(
                             .3
                             .into_iter()
                             .reduce(|min, v| min.min(v))
-                            .unwrap_or(0.0);
+                            .unwrap_or(missing);
                     }
                     Summary::Max => {
                         v[bin] = front
                             .3
                             .into_iter()
                             .reduce(|max, v| max.max(v))
-                            .unwrap_or(0.0);
+                            .unwrap_or(missing);
                     }
                     Summary::Mean => {
                         v[bin] = front.3.into_iter().sum::<f64>() / bin_size;
@@ -747,7 +746,7 @@ fn to_entry_array_bins<I: Iterator<Item = Result<BedEntry, BBIReadError>>>(
                 bin,
                 bin_start,
                 bin_end,
-                vec![0.0; (bin_end - bin_start) as usize],
+                vec![missing; (bin_end - bin_start) as usize],
             ));
         }
         for bin in bin_data.iter() {
@@ -769,7 +768,8 @@ fn to_entry_array_bins<I: Iterator<Item = Result<BedEntry, BBIReadError>>>(
             for i in &mut data
                 [((overlap_start - *bin_start) as usize)..((overlap_end - *bin_start) as usize)]
             {
-                *i = *i + 1.0;
+                // If NAN, then 0.0 + 1.0, else i + 1.0
+                *i = (*i).max(0.0) + 1.0;
             }
         }
     }
@@ -782,14 +782,14 @@ fn to_entry_array_bins<I: Iterator<Item = Result<BedEntry, BBIReadError>>>(
                     .3
                     .into_iter()
                     .reduce(|min, v| min.min(v))
-                    .unwrap_or(0.0);
+                    .unwrap_or(missing);
             }
             Summary::Max => {
                 v[bin] = front
                     .3
                     .into_iter()
                     .reduce(|max, v| max.max(v))
-                    .unwrap_or(0.0);
+                    .unwrap_or(missing);
             }
             Summary::Mean => {
                 v[bin] = front.3.into_iter().sum::<f64>() / bin_size;
@@ -805,9 +805,11 @@ fn to_entry_array_zoom<I: Iterator<Item = Result<ZoomRecord, BBIReadError>>>(
     iter: I,
     summary: Summary,
     bins: usize,
+    missing: f64,
     mut v: ArrayViewMut<'_, f64, numpy::Ix1>,
 ) -> Result<(), BBIReadError> {
     assert_eq!(v.len(), bins);
+    v.fill(missing);
 
     let mut bin_data: VecDeque<(usize, i32, i32, Vec<f64>)> = VecDeque::new();
     let bin_size = (end - start) as f64 / bins as f64;
@@ -829,16 +831,14 @@ fn to_entry_array_zoom<I: Iterator<Item = Result<ZoomRecord, BBIReadError>>>(
                             .3
                             .into_iter()
                             .reduce(|min, v| min.min(v))
-                            .unwrap_or(0.0)
-                            .max(0.0);
+                            .unwrap_or(missing);
                     }
                     Summary::Max => {
                         v[bin] = front
                             .3
                             .into_iter()
                             .reduce(|max, v| max.max(v))
-                            .unwrap_or(0.0)
-                            .max(0.0);
+                            .unwrap_or(missing);
                     }
                     Summary::Mean => {
                         v[bin] = front.3.into_iter().sum::<f64>() / bin_size;
@@ -860,7 +860,7 @@ fn to_entry_array_zoom<I: Iterator<Item = Result<ZoomRecord, BBIReadError>>>(
                 bin,
                 bin_start,
                 bin_end,
-                vec![f64::NAN; (bin_end - bin_start) as usize],
+                vec![missing; (bin_end - bin_start) as usize],
             ));
         }
         for bin in bin_data.iter() {
@@ -883,12 +883,12 @@ fn to_entry_array_zoom<I: Iterator<Item = Result<ZoomRecord, BBIReadError>>>(
             for i in &mut data
                 [((overlap_start - *bin_start) as usize)..((overlap_end - *bin_start) as usize)]
             {
+                *i = i.max(0.0);
                 match summary {
                     Summary::Mean => *i += mean,
                     Summary::Min => *i = i.min(interval.summary.min_val),
                     Summary::Max => *i = i.max(interval.summary.max_val),
                 }
-                *i = i.max(0.0);
             }
         }
     }
@@ -901,16 +901,14 @@ fn to_entry_array_zoom<I: Iterator<Item = Result<ZoomRecord, BBIReadError>>>(
                     .3
                     .into_iter()
                     .reduce(|min, v| min.min(v))
-                    .unwrap_or(0.0)
-                    .max(0.0);
+                    .unwrap_or(missing);
             }
             Summary::Max => {
                 v[bin] = front
                     .3
                     .into_iter()
                     .reduce(|max, v| max.max(v))
-                    .unwrap_or(0.0)
-                    .max(0.0);
+                    .unwrap_or(missing);
             }
             Summary::Mean => {
                 v[bin] = front.3.into_iter().sum::<f64>() / bin_size;
@@ -1924,6 +1922,51 @@ mod test {
 
     #[test]
     fn test_to_entry_array_bins() {
+        fn eq_with_nan_eq(a: f64, b: f64) -> bool {
+            (a.is_nan() && b.is_nan()) || (a == b)
+        }
+
+        #[track_caller]
+        fn assert_equal(found: Vec<f64>, expected: Vec<f64>) {
+            let equal = (found.len() == expected.len()) &&  // zip stops at the shortest
+            found.iter()
+               .zip(expected.iter())
+               .all(|(a,b)| eq_with_nan_eq(*a, *b));
+            if !equal {
+                panic!("Vecs not equal: expected {:?}, found {:?}", expected, found);
+            }
+        }
+
+        let entries = [];
+        let mut arr = Array::from(vec![f64::NAN]);
+        to_entry_array_bins(
+            10,
+            20,
+            entries.into_iter().map(|v| Ok(v)),
+            crate::Summary::Mean,
+            1,
+            f64::NAN,
+            arr.view_mut(),
+        )
+        .unwrap();
+        let res = arr.to_vec();
+        assert_equal(res, [f64::NAN].into_iter().collect::<Vec<_>>());
+
+        let entries = [];
+        let mut arr = Array::from(vec![f64::NAN]);
+        to_entry_array_bins(
+            10,
+            20,
+            entries.into_iter().map(|v| Ok(v)),
+            crate::Summary::Mean,
+            1,
+            0.0,
+            arr.view_mut(),
+        )
+        .unwrap();
+        let res = arr.to_vec();
+        assert_equal(res, [0.0].into_iter().collect::<Vec<_>>());
+
         let entries = [BedEntry {
             start: 10,
             end: 20,
@@ -1936,11 +1979,12 @@ mod test {
             entries.into_iter().map(|v| Ok(v)),
             crate::Summary::Mean,
             1,
+            f64::NAN,
             arr.view_mut(),
         )
         .unwrap();
         let res = arr.to_vec();
-        assert_eq!(res, [1.0].into_iter().collect::<Vec<_>>());
+        assert_equal(res, [1.0].into_iter().collect::<Vec<_>>());
 
         let entries = [BedEntry {
             start: 10,
@@ -1954,11 +1998,12 @@ mod test {
             entries.into_iter().map(|v| Ok(v)),
             crate::Summary::Mean,
             2,
+            f64::NAN,
             arr.view_mut(),
         )
         .unwrap();
         let res = arr.to_vec();
-        assert_eq!(res, [1.0, 1.0].into_iter().collect::<Vec<_>>());
+        assert_equal(res, [1.0, 1.0].into_iter().collect::<Vec<_>>());
 
         let entries = [
             BedEntry {
@@ -1979,11 +2024,12 @@ mod test {
             entries.clone().into_iter().map(|v| Ok(v)),
             crate::Summary::Mean,
             2,
+            f64::NAN,
             arr.view_mut(),
         )
         .unwrap();
         let res = arr.to_vec();
-        assert_eq!(res, [1.0, 2.0].into_iter().collect::<Vec<_>>());
+        assert_equal(res, [1.0, 2.0].into_iter().collect::<Vec<_>>());
         let mut arr = Array::from(vec![f64::NAN]);
         to_entry_array_bins(
             10,
@@ -1991,11 +2037,12 @@ mod test {
             entries.clone().into_iter().map(|v| Ok(v)),
             crate::Summary::Min,
             1,
+            f64::NAN,
             arr.view_mut(),
         )
         .unwrap();
         let res = arr.to_vec();
-        assert_eq!(res, [1.0].into_iter().collect::<Vec<_>>());
+        assert_equal(res, [1.0].into_iter().collect::<Vec<_>>());
         let mut arr = Array::from(vec![f64::NAN]);
         to_entry_array_bins(
             10,
@@ -2003,11 +2050,12 @@ mod test {
             entries.clone().into_iter().map(|v| Ok(v)),
             crate::Summary::Max,
             1,
+            f64::NAN,
             arr.view_mut(),
         )
         .unwrap();
         let res = arr.to_vec();
-        assert_eq!(res, [2.0].into_iter().collect::<Vec<_>>());
+        assert_equal(res, [2.0].into_iter().collect::<Vec<_>>());
 
         let entries = [
             BedEntry {
@@ -2033,11 +2081,12 @@ mod test {
             entries.clone().into_iter().map(|v| Ok(v)),
             crate::Summary::Mean,
             2,
+            f64::NAN,
             arr.view_mut(),
         )
         .unwrap();
         let res = arr.to_vec();
-        assert_eq!(res, [1.0, 3.0].into_iter().collect::<Vec<_>>());
+        assert_equal(res, [1.0, 3.0].into_iter().collect::<Vec<_>>());
         let mut arr = Array::from(vec![f64::NAN]);
         to_entry_array_bins(
             10,
@@ -2045,11 +2094,12 @@ mod test {
             entries.clone().into_iter().map(|v| Ok(v)),
             crate::Summary::Min,
             1,
+            f64::NAN,
             arr.view_mut(),
         )
         .unwrap();
         let res = arr.to_vec();
-        assert_eq!(res, [1.0].into_iter().collect::<Vec<_>>());
+        assert_equal(res, [1.0].into_iter().collect::<Vec<_>>());
         let mut arr = Array::from(vec![f64::NAN]);
         to_entry_array_bins(
             10,
@@ -2057,10 +2107,11 @@ mod test {
             entries.clone().into_iter().map(|v| Ok(v)),
             crate::Summary::Max,
             1,
+            f64::NAN,
             arr.view_mut(),
         )
         .unwrap();
         let res = arr.to_vec();
-        assert_eq!(res, [3.0].into_iter().collect::<Vec<_>>());
+        assert_equal(res, [3.0].into_iter().collect::<Vec<_>>());
     }
 }

--- a/pybigtools/tests/test_api.py
+++ b/pybigtools/tests/test_api.py
@@ -1,0 +1,111 @@
+import pybigtools
+import math
+import numpy as np
+
+def test_api():
+    b = pybigtools.open('../bigtools/resources/test/valid.bigWig', 'r')
+
+    # Check type of file
+    assert b.is_bigbed == False
+    assert b.is_bigwig == True
+
+    # No args => dict
+    assert b.chroms() == {'chr17': 83257441}
+    # Arg with chrom name => length
+    assert b.chroms('chr17') == 83257441
+    # Missing chrom => None
+    assert b.chroms('chr11') == None
+
+    # Get a list of zooms
+    assert b.zooms() == [10, 40, 160, 640, 2560, 10240, 40960, 163840, 655360, 2621440]
+
+    # Even bigwigs have sql (a sql representing bedGraph)
+    assert "bedGraph" in b.sql()
+    # We can parse the sql
+    assert b.sql(True)['name'] == 'bedGraph'
+
+    # (chrom, None, None) => all records on chrom
+    assert len(list(b.records('chr17'))) == 100000
+    # (chrom, start, None) => all records from (start, <chrom_end>)
+    assert len(list(b.records('chr17', 100000))) == 91360
+    # (chrom, start, end) => all records from (start, end)
+    assert len(list(b.records('chr17', 100000, 110000))) == 1515
+    # Out of bounds start/end are truncated
+    assert len(list(b.records('chr17', -1000, 100000))) == 8641
+    assert len(list(b.records('chr17', -1000, -500))) == 0
+    assert len(list(b.records('chr17', 0, 84000000))) == 100000
+    assert next(b.records('chr17')) == (59898, 59900, 0.06791999936103821)
+    # Unknown chrom  => exception
+    try:
+        b.zoom_records('chr11')
+    except:
+        pass
+    else:
+        assert False
+
+    # (chrom, None, None) => all records on chrom
+    assert len(list(b.zoom_records(10, 'chr17'))) == 13811
+    # (chrom, start, None) => all records from (start, <chrom_end>)
+    assert len(list(b.zoom_records(10, 'chr17', 100000))) == 10872
+    # (chrom, start, end) => all records from (start, end)
+    assert len(list(b.zoom_records(10, 'chr17', 100000, 110000))) == 766
+    # Out of bounds start/end are truncated
+    assert len(list(b.zoom_records(10, 'chr17', -1000, 100000))) == 2940
+    assert len(list(b.zoom_records(10, 'chr17', -1000, -500))) == 0
+    assert len(list(b.zoom_records(10, 'chr17', 0, 84000000))) == 13811
+    assert next(b.zoom_records(10, 'chr17', 0, 100000)) == (59898, 59908, {'total_items': 0, 'bases_covered': 10, 'min_val': 0.06791999936103821, 'max_val': 0.16627000272274017, 'sum': 1.4660000801086426, 'sum_squares': 0.2303919643163681})
+    assert next(b.zoom_records(160, 'chr17', 0, 100000)) == (59898, 60058, {'total_items': 0, 'bases_covered': 160, 'min_val': 0.06791999936103821, 'max_val': 0.8688300251960754, 'sum': 101.3516616821289, 'sum_squares': 80.17473602294922})
+    # Unknown zoom  => exception
+    try:
+        b.zoom_records(0, 'chr17')
+    except:
+        pass
+    else:
+        assert False
+    # Unknown chrom  => exception
+    try:
+        b.zoom_records(10, 'chr11')
+    except:
+        pass
+    else:
+        assert False
+
+    assert len(list(b.values('chr17', 100000, 110000))) == 10000
+    assert len(list(b.values('chr17', 100000, 110000, 10))) == 10
+    assert b.values('chr17', 100000, 110000, 10)[0] == 0.37435242314338685
+    assert b.values('chr17', 100000, 110000, 10, 'max')[0] == 1.1978399753570557
+    assert b.values('chr17', 100000, 110000, 10, 'min')[0] == 0.05403999984264374
+    assert b.values('chr17', 100000, 110000, 10, 'mean',  True)[0] == 0.37885534041374924
+    assert list(b.values('chr17', 59890, 59900, 10, 'mean', True)) == [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.06791999936103821, 0.06791999936103821]
+    assert list(b.values('chr17', 59890, 59900, 10, 'mean', True, -1.0)) == [-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, 0.06791999936103821, 0.06791999936103821]
+    assert math.isnan(b.values('chr17', -10, 10, 20, 'mean', True, 0.0)[0])
+    assert not math.isnan(b.values('chr17', -10, 10, 20, 'mean', True, 0.0)[19])
+    assert b.values('chr17', -10, 10, 20, 'mean', True, 0.0, 0.0)[0] == 0.0
+    arr = np.zeros(20)
+    ret_arr = b.values('chr17', -10, 10, 20, 'mean', True, 0.0, np.nan, arr)
+    # The returned array is the same as the one passed, so both show the same values
+    assert math.isnan(arr[0])
+    assert arr[19] == 0.0
+    assert math.isnan(ret_arr[0])
+    assert ret_arr[19] == 0.0
+
+    b.close()
+    # Closing means file is not usable
+    try:
+        b.chroms()
+    except:
+        pass
+    else:
+        assert False
+
+    b = pybigtools.open('../bigtools/resources/test/valid.bigWig', 'r')
+    # Files are closed when exiting a context manager
+    with b:
+      pass
+    try:
+        b.chroms()
+    except:
+        pass
+    else:
+        assert False
+

--- a/pybigtools/tests/test_api.py
+++ b/pybigtools/tests/test_api.py
@@ -123,10 +123,10 @@ def test_autosql(bw, bb):
     # Even bigwigs have sql (a sql representing bedGraph)
     assert "bedGraph" in bw.sql()
     # We can parse the sql
-    # assert bw.sql(True)['name'] == 'bedGraph'
+    assert bw.sql(True)['name'] == 'bedGraph'
 
-    # bb.sql()
-    # BBIReadError: The file was invalid: Invalid autosql: not UTF-8
+    # Unfortunately, this test bigBed doesn't actually have autosql
+    assert len(bb.sql()) == 0
 
 
 def test_records(bw, bb):

--- a/pybigtools/tests/test_api.py
+++ b/pybigtools/tests/test_api.py
@@ -74,9 +74,9 @@ def test_chroms(bw, bb):
     assert bw.chroms("chr17") == 83257441
     assert bb.chroms("chr21") == 48129895
 
-    # Missing chrom => None
-    assert bw.chroms("chr11") is None
-    assert bb.chroms("chr11") is None
+    # Missing chrom => KeyError
+    pytest.raises(KeyError, bw.chroms, "chr11")
+    pytest.raises(KeyError, bb.chroms, "chr11")
 
 
 def test_zooms(bw, bb):

--- a/pybigtools/tests/test_api.py
+++ b/pybigtools/tests/test_api.py
@@ -246,8 +246,8 @@ def test_values(bw, bb):
     assert len(bw.values("chr17", 100000, 110000, 10)) == 10
     assert len(bb.values("chr21", 10_148_000, 10_158_000, 10)) == 10
 
-    assert bw.values("chr17", 100000, 110000, 10)[0] == 0.37435242314338685
-    assert bb.values("chr21", 10_148_000, 10_158_000, 10)[0] == 0.175
+    assert bw.values("chr17", 100000, 110000, 10)[0] == 0.44886381671868925
+    assert bb.values("chr21", 10_148_000, 10_158_000, 10)[0] == 1.0
 
     assert bw.values("chr17", 100000, 110000, 10, "max")[0] == 1.1978399753570557
     assert bb.values("chr21", 10_148_000, 10_158_000, 10, "max")[0] == 1.0
@@ -257,11 +257,11 @@ def test_values(bw, bb):
 
     assert (
         bw.values("chr17", 100000, 110000, 10, "mean", exact=True)[0]
-        == 0.37885534041374924
+        == 0.4542629980980206
     )
     assert (
         bb.values("chr21", 10_148_000, 10_158_000, 10, "mean", exact=True)[0]
-        == 0.175
+        == 1.0
     )
 
     assert list(bw.values("chr17", 59890, 59900, 10, "mean", exact=True)) == [

--- a/pybigtools/tests/test_api.py
+++ b/pybigtools/tests/test_api.py
@@ -1,111 +1,291 @@
-import pybigtools
 import math
+import pathlib
+from io import BytesIO
+
 import numpy as np
+import pytest
 
-def test_api():
-    b = pybigtools.open('../bigtools/resources/test/valid.bigWig', 'r')
+import pybigtools
 
-    # Check type of file
-    assert b.is_bigbed == False
-    assert b.is_bigwig == True
+TEST_DIR = pathlib.Path(__file__).parent
+REPO_ROOT = TEST_DIR.parent.parent
 
+
+def test_open_close():
+    path = str(REPO_ROOT / "bigtools/resources/test/valid.bigWig")
+    b = pybigtools.open(path, "r")
+    b.close()
+    assert pytest.raises(pybigtools.BBIFileClosed, b.chroms)
+
+    # Files are closed when exiting a context manager
+    with pybigtools.open(path, "r") as b:
+        pass
+    assert pytest.raises(pybigtools.BBIFileClosed, b.chroms)
+
+    # Invalid file-like object
+    s = BytesIO()
+    assert pytest.raises(pybigtools.BBIReadError, pybigtools.open, s, "r")
+
+
+@pytest.fixture
+def bw():
+    path = str(REPO_ROOT / "bigtools/resources/test/valid.bigWig")
+    return pybigtools.open(path, "r")
+
+
+@pytest.fixture
+def bb():
+    path = str(TEST_DIR / "data/bigBedExample.bb")
+    return pybigtools.open(path, "r")
+
+
+def test_check_filetype(bw, bb):
+    assert not bw.is_bigbed
+    assert bw.is_bigwig
+
+    assert bb.is_bigbed
+    assert not bb.is_bigwig
+
+
+def test_info(bw):
+    assert bw.info() == {
+        'version': 4,
+        'isCompressed': True,
+        'primaryDataSize': 603305,
+        'zoomLevels': 10,
+        'chromCount': 1,
+        'summary': {
+            'basesCovered': 137894,
+            'sum': 89001714.97238067,
+            'mean': 645.4357330440822,
+            'min': 0.006219999864697456,
+            'max': 14254.0,
+            'std': 751.0146556298351
+        },
+    }
+
+
+def test_chroms(bw, bb):
     # No args => dict
-    assert b.chroms() == {'chr17': 83257441}
+    assert bw.chroms() == {"chr17": 83_257_441}
+    assert bb.chroms() == {"chr21": 48_129_895}
+
     # Arg with chrom name => length
-    assert b.chroms('chr17') == 83257441
+    assert bw.chroms("chr17") == 83257441
+    assert bb.chroms("chr21") == 48129895
+
     # Missing chrom => None
-    assert b.chroms('chr11') == None
+    assert bw.chroms("chr11") is None
+    assert bb.chroms("chr11") is None
 
+
+def test_zooms(bw, bb):
     # Get a list of zooms
-    assert b.zooms() == [10, 40, 160, 640, 2560, 10240, 40960, 163840, 655360, 2621440]
+    assert bw.zooms() == [10, 40, 160, 640, 2560, 10240, 40960, 163840, 655360, 2621440]
+    assert bb.zooms() == [3911, 39110, 391100, 3911000, 39110000]
 
+
+def test_autosql(bw, bb):
     # Even bigwigs have sql (a sql representing bedGraph)
-    assert "bedGraph" in b.sql()
+    assert "bedGraph" in bw.sql()
     # We can parse the sql
-    assert b.sql(True)['name'] == 'bedGraph'
+    # assert bw.sql(True)['name'] == 'bedGraph'
 
+    # bb.sql()
+    # BBIReadError: The file was invalid: Invalid autosql: not UTF-8
+
+
+def test_records(bw, bb):
     # (chrom, None, None) => all records on chrom
-    assert len(list(b.records('chr17'))) == 100000
+    assert len(list(bw.records("chr17"))) == 100_000
+    assert len(list(bb.records("chr21"))) == 14_810
+
     # (chrom, start, None) => all records from (start, <chrom_end>)
-    assert len(list(b.records('chr17', 100000))) == 91360
+    assert len(list(bw.records("chr17", 100_000))) == 91_360
+    assert len(list(bb.records("chr21", 10_000_000))) == 14_799
+
     # (chrom, start, end) => all records from (start, end)
-    assert len(list(b.records('chr17', 100000, 110000))) == 1515
+    assert len(list(bw.records("chr17", 100_000, 110_000))) == 1515
+    assert len(list(bb.records("chr21", 10_000_000, 20_000_000))) == 233
+
     # Out of bounds start/end are truncated
-    assert len(list(b.records('chr17', -1000, 100000))) == 8641
-    assert len(list(b.records('chr17', -1000, -500))) == 0
-    assert len(list(b.records('chr17', 0, 84000000))) == 100000
-    assert next(b.records('chr17')) == (59898, 59900, 0.06791999936103821)
+    x = list(bw.records("chr17", 0, 100_000))
+    assert len(x) == 8641
+    assert list(bw.records("chr17", -1000, 100_000)) == x
+    x = list(bb.records("chr21", 0, 10_000_000))
+    assert len(x) == 11
+    assert list(bb.records("chr21", -1000, 10_000_000)) == x
+
+    y = list(bw.records("chr17", 0, bw.chroms("chr17")))
+    assert len(y) == 100_000
+    assert list(bw.records("chr17", 0, bw.chroms("chr17") * 2)) == y
+    assert next(bw.records("chr17")) == (59898, 59900, 0.06791999936103821)
+    y = list(bb.records("chr21", 0, bb.chroms("chr21")))
+    assert len(y) == 14810
+    assert list(bb.records("chr21", 0, bb.chroms("chr21") * 2)) == y
+    assert next(bb.records("chr21")) == (9434178, 9434609)
+
+    # Fully out of bounds ranges return no records
+    assert len(list(bw.records("chr17", -1000, -500))) == 0
+    assert len(list(bw.records("chr17", 83_257_441, 84_000_000))) == 0
+
+    assert len(list(bb.records("chr21", -1000, -500))) == 0
+    assert len(list(bb.records("chr21", 48_129_895, 49_000_000))) == 0
+
     # Unknown chrom  => exception
-    try:
-        b.zoom_records('chr11')
-    except:
-        pass
-    else:
-        assert False
+    assert pytest.raises(KeyError, bw.records, "chr11")
+    assert pytest.raises(KeyError, bb.records, "chr11")
 
+
+def test_zoom_records(bw, bb):
     # (chrom, None, None) => all records on chrom
-    assert len(list(b.zoom_records(10, 'chr17'))) == 13811
+    assert len(list(bw.zoom_records(10, "chr17"))) == 13811
+    assert len(list(bb.zoom_records(3911, "chr21"))) == 1676
+
     # (chrom, start, None) => all records from (start, <chrom_end>)
-    assert len(list(b.zoom_records(10, 'chr17', 100000))) == 10872
+    assert len(list(bw.zoom_records(10, "chr17", 100_000))) == 10872
+    assert len(list(bb.zoom_records(3911, "chr21", 10_000_000))) == 1670
+
     # (chrom, start, end) => all records from (start, end)
-    assert len(list(b.zoom_records(10, 'chr17', 100000, 110000))) == 766
+    assert len(list(bw.zoom_records(10, "chr17", 100_000, 110_000))) == 766
+    assert len(list(bb.zoom_records(3911, "chr21", 10_000_000, 20_000_000))) == 154
+
     # Out of bounds start/end are truncated
-    assert len(list(b.zoom_records(10, 'chr17', -1000, 100000))) == 2940
-    assert len(list(b.zoom_records(10, 'chr17', -1000, -500))) == 0
-    assert len(list(b.zoom_records(10, 'chr17', 0, 84000000))) == 13811
-    assert next(b.zoom_records(10, 'chr17', 0, 100000)) == (59898, 59908, {'total_items': 0, 'bases_covered': 10, 'min_val': 0.06791999936103821, 'max_val': 0.16627000272274017, 'sum': 1.4660000801086426, 'sum_squares': 0.2303919643163681})
-    assert next(b.zoom_records(160, 'chr17', 0, 100000)) == (59898, 60058, {'total_items': 0, 'bases_covered': 160, 'min_val': 0.06791999936103821, 'max_val': 0.8688300251960754, 'sum': 101.3516616821289, 'sum_squares': 80.17473602294922})
+    x = list(bw.zoom_records(10, "chr17", 0, 100_000))
+    assert len(x) == 2940
+    assert list(bw.zoom_records(10, "chr17", -1000, 100_000)) == x
+    x = list(bb.zoom_records(3911, "chr21", 0, 10_000_000))
+    assert len(x) == 6
+    assert list(bb.zoom_records(3911, "chr21", -1000, 10_000_000)) == x
+
+    y = list(bw.zoom_records(10, "chr17", 0, bw.chroms("chr17")))
+    assert len(y) == 13811
+    assert list(bw.zoom_records(10, "chr17", 0, bw.chroms("chr17") * 2)) == y
+    y = list(bb.zoom_records(3911, "chr21", 0, bb.chroms("chr21")))
+    assert len(y) == 1676
+    assert list(bb.zoom_records(3911, "chr21", 0, bb.chroms("chr21") * 2)) == y
+
+    # Fully out of bounds ranges return no records
+    assert len(list(bw.zoom_records(10, "chr17", -1000, -500))) == 0
+    assert len(list(bw.zoom_records(10, "chr17", 83_257_441, 84_000_000))) == 0
+    assert len(list(bb.zoom_records(3911, "chr21", -1000, -500))) == 0
+    assert len(list(bb.zoom_records(3911, "chr21", 48_129_895, 49_000_000))) == 0
+
+    assert next(bw.zoom_records(10, "chr17", 0, 100_000)) == (
+        59898,
+        59908,
+        {
+            "total_items": 0,
+            "bases_covered": 10,
+            "min_val": 0.06791999936103821,
+            "max_val": 0.16627000272274017,
+            "sum": 1.4660000801086426,
+            "sum_squares": 0.2303919643163681,
+        },
+    )
+    assert next(bw.zoom_records(160, "chr17", 0, 100000)) == (
+        59898,
+        60058,
+        {
+            "total_items": 0,
+            "bases_covered": 160,
+            "min_val": 0.06791999936103821,
+            "max_val": 0.8688300251960754,
+            "sum": 101.3516616821289,
+            "sum_squares": 80.17473602294922,
+        },
+    )
+
     # Unknown zoom  => exception
-    try:
-        b.zoom_records(0, 'chr17')
-    except:
-        pass
-    else:
-        assert False
-    # Unknown chrom  => exception
-    try:
-        b.zoom_records(10, 'chr11')
-    except:
-        pass
-    else:
-        assert False
+    assert pytest.raises(KeyError, bw.zoom_records, 0, "chr17")
+    assert pytest.raises(KeyError, bb.zoom_records, 0, "chr21")
 
-    assert len(list(b.values('chr17', 100000, 110000))) == 10000
-    assert len(list(b.values('chr17', 100000, 110000, 10))) == 10
-    assert b.values('chr17', 100000, 110000, 10)[0] == 0.37435242314338685
-    assert b.values('chr17', 100000, 110000, 10, 'max')[0] == 1.1978399753570557
-    assert b.values('chr17', 100000, 110000, 10, 'min')[0] == 0.05403999984264374
-    assert b.values('chr17', 100000, 110000, 10, 'mean',  True)[0] == 0.37885534041374924
-    assert list(b.values('chr17', 59890, 59900, 10, 'mean', True)) == [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.06791999936103821, 0.06791999936103821]
-    assert list(b.values('chr17', 59890, 59900, 10, 'mean', True, -1.0)) == [-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, 0.06791999936103821, 0.06791999936103821]
-    assert math.isnan(b.values('chr17', -10, 10, 20, 'mean', True, 0.0)[0])
-    assert not math.isnan(b.values('chr17', -10, 10, 20, 'mean', True, 0.0)[19])
-    assert b.values('chr17', -10, 10, 20, 'mean', True, 0.0, 0.0)[0] == 0.0
-    arr = np.zeros(20)
-    ret_arr = b.values('chr17', -10, 10, 20, 'mean', True, 0.0, np.nan, arr)
+    # Unknown chrom  => exception
+    assert pytest.raises(KeyError, bw.zoom_records, 10, "chr11")
+    assert pytest.raises(KeyError, bb.zoom_records, 3911, "chr11")
+
+
+def test_values(bw, bb):
+    assert len(bw.values("chr17", 100_000, 110_000)) == 10_000
+    assert len(bb.values("chr21", 10_148_000, 10_158_000)) == 10_000
+
+    assert len(bw.values("chr17", 100000, 110000, 10)) == 10
+    assert len(bb.values("chr21", 10_148_000, 10_158_000, 10)) == 10
+
+    assert bw.values("chr17", 100000, 110000, 10)[0] == 0.37435242314338685
+    assert bb.values("chr21", 10_148_000, 10_158_000, 10)[0] == 0.175
+
+    assert bw.values("chr17", 100000, 110000, 10, "max")[0] == 1.1978399753570557
+    assert bb.values("chr21", 10_148_000, 10_158_000, 10, "max")[0] == 1.0
+
+    assert bw.values("chr17", 100000, 110000, 10, "min")[0] == 0.05403999984264374
+    assert bb.values("chr21", 10_148_000, 10_158_000, 10, "min")[0] == 0.0
+
+    assert (
+        bw.values("chr17", 100000, 110000, 10, "mean", exact=True)[0]
+        == 0.37885534041374924
+    )
+    assert (
+        bb.values("chr21", 10_148_000, 10_158_000, 10, "mean", exact=True)[0]
+        == 0.175
+    )
+
+    assert list(bw.values("chr17", 59890, 59900, 10, "mean", exact=True)) == [
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.06791999936103821,
+        0.06791999936103821,
+    ]
+
+    assert list(
+        bw.values("chr17", 59890, 59900, 10, "mean", exact=True, missing=-1.0)
+    ) == [
+        -1.0,
+        -1.0,
+        -1.0,
+        -1.0,
+        -1.0,
+        -1.0,
+        -1.0,
+        -1.0,
+        0.06791999936103821,
+        0.06791999936103821,
+    ]
+
+    x = bw.values("chr17", -10, 10, 20, "mean", exact=True, missing=0.0)
+    assert math.isnan(x[0])
+    assert not math.isnan(x[19])
+    x = bb.values("chr21", -10, 10, 20, "mean", exact=True, missing=0.0)
+    assert math.isnan(x[0])
+    assert not math.isnan(x[19])
+
+    x = bw.values("chr17", -10, 10, 20, "mean", exact=True, missing=0.0, oob=0.0)
+    assert x[0] == 0.0
+    x = bb.values("chr21", -10, 10, 20, "mean", exact=True, missing=0.0, oob=0.0)
+    assert x[0] == 0.0
+
     # The returned array is the same as the one passed, so both show the same values
+    arr = np.zeros(20)
+    ret_arr = bw.values(
+        "chr17", -10, 10, 20, "mean", exact=True, missing=0.0, oob=np.nan, arr=arr
+    )
     assert math.isnan(arr[0])
     assert arr[19] == 0.0
     assert math.isnan(ret_arr[0])
     assert ret_arr[19] == 0.0
+    assert np.array_equal(arr, ret_arr, equal_nan=True)
 
-    b.close()
-    # Closing means file is not usable
-    try:
-        b.chroms()
-    except:
-        pass
-    else:
-        assert False
-
-    b = pybigtools.open('../bigtools/resources/test/valid.bigWig', 'r')
-    # Files are closed when exiting a context manager
-    with b:
-      pass
-    try:
-        b.chroms()
-    except:
-        pass
-    else:
-        assert False
-
+    ret_arr = bb.values(
+        "chr21", -10, 10, 20, "mean", exact=True, missing=0.0, oob=np.nan, arr=arr
+    )
+    assert math.isnan(arr[0])
+    assert arr[19] == 0.0
+    assert math.isnan(ret_arr[0])
+    assert ret_arr[19] == 0.0
+    assert np.array_equal(arr, ret_arr, equal_nan=True)

--- a/pybigtools/tests/test_api.py
+++ b/pybigtools/tests/test_api.py
@@ -323,3 +323,13 @@ def test_values(bw, bb):
     assert math.isnan(ret_arr[0])
     assert ret_arr[19] == 0.0
     assert np.array_equal(arr, ret_arr, equal_nan=True)
+
+    # Some differences in estimates between pybigtools to other libs
+    vals = bw.values("chr17", 85525, 85730, bins=2, exact=False)
+    assert list(vals) == [0.15392776003070907, 2.728891665264241]
+    vals = bw.values("chr17", 85525, 85730, bins=2, exact=True)
+    assert list(vals) == [0.06770934917680595, 2.4864424403431347]
+    vals = bw.values("chr17", 59900, 60105, bins=2, exact=False)
+    assert list(vals) == [0.5358060553962108, 0.5513471488813751]
+    vals = bw.values("chr17", 59900, 60105, bins=2, exact=True)
+    assert list(vals) == [0.5362001863472602, 0.5527710799959679]

--- a/pybigtools/tests/test_api.py
+++ b/pybigtools/tests/test_api.py
@@ -325,6 +325,9 @@ def test_values(bw, bb):
     assert np.array_equal(arr, ret_arr, equal_nan=True)
 
     # Some differences in estimates between pybigtools to other libs
+    # Namely, bigtools calculates estimates by taking the
+    # sum of nanmeans over covered bases (summary.sum/summary.covered_bases) and dividing by covered bases (overlap between zooom and bin)
+    # So, including these as cases where the calculated value is different
     vals = bw.values("chr17", 85525, 85730, bins=2, exact=False)
     assert list(vals) == [0.15392776003070907, 2.728891665264241]
     vals = bw.values("chr17", 85525, 85730, bins=2, exact=True)
@@ -333,3 +336,8 @@ def test_values(bw, bb):
     assert list(vals) == [0.5358060553962108, 0.5513471488813751]
     vals = bw.values("chr17", 59900, 60105, bins=2, exact=True)
     assert list(vals) == [0.5362001863472602, 0.5527710799959679]
+
+    vals = bb.values("chr21", 14_760_000, 14_800_000, bins=1, exact=False)
+    assert list(vals) == [1.2572170068028603]
+    vals = bb.values("chr21", 14_760_000, 14_800_000, bins=1, exact=True)
+    assert list(vals) == [1.3408662900188324]

--- a/pybigtools/tests/test_api.py
+++ b/pybigtools/tests/test_api.py
@@ -17,6 +17,12 @@ def test_open_close():
     b.close()
     assert pytest.raises(pybigtools.BBIFileClosed, b.chroms)
 
+    # Works with pathlib.Path
+    path = REPO_ROOT / "bigtools/resources/test/valid.bigWig"
+    b = pybigtools.open(path, "r")
+    b.close()
+    assert pytest.raises(pybigtools.BBIFileClosed, b.chroms)
+
     # Files are closed when exiting a context manager
     with pybigtools.open(path, "r") as b:
         pass

--- a/pybigtools/tests/test_api.py
+++ b/pybigtools/tests/test_api.py
@@ -60,6 +60,12 @@ def test_open_filelike():
         with pybigtools.open(f, "r") as b:
             assert b.chroms() == {'chr21': 48_129_895}
 
+def test_contextmanager_exception():
+    class RaisesException(Exception):
+        pass
+    with pytest.raises(RaisesException):
+        with pybigtools.open(REPO_ROOT / "bigtools/resources/test/valid.bigWig", "r"):
+            raise RaisesException()
 
 @pytest.fixture
 def bw():


### PR DESCRIPTION
Closes #33

This overhauls the pybigtools API. In large part, it unifies the APIs for reading bigWigs and bigBeds. However, it also significantly changes the `values` method, adding much more functionality and flexibility.

There are also a couple other minor additions and bug fixes to the core bigtools code.