### PR TITLE
Add `--clip` argument to `bedgraphtobigwig`

### DIFF
--- a/bigtools/src/bbi/bbiwrite.rs
+++ b/bigtools/src/bbi/bbiwrite.rs
@@ -128,7 +128,7 @@ impl<E: Error> From<ProcessDataError> for BBIProcessError<E> {
     fn from(value: ProcessDataError) -> Self {
         match value {
             ProcessDataError::InvalidInput(e) => BBIProcessError::InvalidInput(e),
-            ProcessDataError::InvalidChromosome(e, _clip) => BBIProcessError::InvalidChromosome(e),
+            ProcessDataError::InvalidChromosome(e) => BBIProcessError::InvalidChromosome(e),
             ProcessDataError::IoError(e) => BBIProcessError::IoError(e),
         }
     }
@@ -574,7 +574,7 @@ pub trait BBIDataSource: Sized {
 
     fn process_to_bbi<
         P: BBIDataProcessor<Value = Self::Value> + Send + 'static,
-        StartProcessing: FnMut(String) -> Result<P, ProcessDataError>,
+        StartProcessing: FnMut(String) -> Result<Option<P>, ProcessDataError>,
         Advance: FnMut(P),
     >(
         &mut self,
@@ -718,7 +718,7 @@ pub enum ProcessDataError {
     #[error("{}", .0)]
     InvalidInput(String),
     #[error("{}", .0)]
-    InvalidChromosome(String, bool),
+    InvalidChromosome(String),
     #[error("{}", .0)]
     IoError(#[from] io::Error),
 }
@@ -829,8 +829,7 @@ pub(crate) fn write_vals<
                 return Err(ProcessDataError::InvalidChromosome(format!(
                     "Input bedGraph contains chromosome that isn't in the input chrom sizes: {}",
                     chrom
-                ),
-                options.clip
+                )
             ));
             }
         };

--- a/bigtools/src/bbi/bbiwrite.rs
+++ b/bigtools/src/bbi/bbiwrite.rs
@@ -91,6 +91,7 @@ pub struct BBIWriteOptions {
     pub input_sort_type: InputSortType,
     pub channel_size: usize,
     pub inmemory: bool,
+    pub clip: bool
 }
 
 impl Default for BBIWriteOptions {
@@ -105,6 +106,7 @@ impl Default for BBIWriteOptions {
             input_sort_type: InputSortType::ALL,
             channel_size: 100,
             inmemory: false,
+            clip: false
         }
     }
 }

--- a/bigtools/src/bbi/bbiwrite.rs
+++ b/bigtools/src/bbi/bbiwrite.rs
@@ -822,10 +822,14 @@ pub(crate) fn write_vals<
 
         (zooms_channels, ftx)
     }
-    let mut do_read = |chrom: String| -> Result<_, ProcessDataError> {
+
+    let mut do_read = |chrom: String| -> Result<Option<_>, ProcessDataError> {
         let length = match chrom_sizes.get(&chrom) {
             Some(length) => *length,
             None => {
+                if options.clip {
+                    return Ok(None)
+                }
                 return Err(ProcessDataError::InvalidChromosome(format!(
                     "Input bedGraph contains chromosome that isn't in the input chrom sizes: {}",
                     chrom
@@ -833,6 +837,7 @@ pub(crate) fn write_vals<
             ));
             }
         };
+
         // Make a new id for the chromosome
         let chrom_id = chrom_ids.get_id(&chrom);
 
@@ -845,9 +850,10 @@ pub(crate) fn write_vals<
             options.clone(),
             runtime.handle().clone(),
             chrom,
-            length,
+            length
         );
-        Ok(P::create(internal_data))
+        
+        Ok(Some(P::create(internal_data)))
     };
 
     let mut advance = |p: P| {
@@ -966,11 +972,13 @@ pub(crate) fn write_vals_no_zoom<
         let length = match chrom_sizes.get(&chrom) {
             Some(length) => *length,
             None => {
+                if options.clip {
+                    return Ok(None)
+                }
                 return Err(ProcessDataError::InvalidChromosome(format!(
                     "Input bedGraph contains chromosome that isn't in the input chrom sizes: {}",
                     chrom
-                ),
-                options.clip
+                )
             ));
             }
         };
@@ -987,7 +995,7 @@ pub(crate) fn write_vals_no_zoom<
             chrom,
             length,
         );
-        Ok(P::create(internal_data))
+        Ok(Some(P::create(internal_data)))
     };
 
     let mut advance = |p: P| {
@@ -1122,7 +1130,7 @@ pub(crate) fn write_zoom_vals<
 
     let mut max_uncompressed_buf_size = 0;
 
-    let mut do_read = |chrom: String| -> Result<P, ProcessDataError> {
+    let mut do_read = |chrom: String| -> Result<Option<P>, ProcessDataError> {
         // Make a new id for the chromosome
         let chrom_id = *chrom_ids
             .get(&chrom)
@@ -1154,7 +1162,8 @@ pub(crate) fn write_zoom_vals<
             options.clone(),
             runtime.handle().clone(),
         );
-        Ok(P::create(internal_data))
+
+        Ok(Some(P::create(internal_data)))
     };
 
     let mut advance = |p: P| {

--- a/bigtools/src/bbi/bbiwrite.rs
+++ b/bigtools/src/bbi/bbiwrite.rs
@@ -128,7 +128,7 @@ impl<E: Error> From<ProcessDataError> for BBIProcessError<E> {
     fn from(value: ProcessDataError) -> Self {
         match value {
             ProcessDataError::InvalidInput(e) => BBIProcessError::InvalidInput(e),
-            ProcessDataError::InvalidChromosome(e) => BBIProcessError::InvalidChromosome(e),
+            ProcessDataError::InvalidChromosome(e, _clip) => BBIProcessError::InvalidChromosome(e),
             ProcessDataError::IoError(e) => BBIProcessError::IoError(e),
         }
     }
@@ -718,7 +718,7 @@ pub enum ProcessDataError {
     #[error("{}", .0)]
     InvalidInput(String),
     #[error("{}", .0)]
-    InvalidChromosome(String),
+    InvalidChromosome(String, bool),
     #[error("{}", .0)]
     IoError(#[from] io::Error),
 }
@@ -829,7 +829,9 @@ pub(crate) fn write_vals<
                 return Err(ProcessDataError::InvalidChromosome(format!(
                     "Input bedGraph contains chromosome that isn't in the input chrom sizes: {}",
                     chrom
-                )));
+                ),
+                options.clip
+            ));
             }
         };
         // Make a new id for the chromosome
@@ -968,7 +970,9 @@ pub(crate) fn write_vals_no_zoom<
                 return Err(ProcessDataError::InvalidChromosome(format!(
                     "Input bedGraph contains chromosome that isn't in the input chrom sizes: {}",
                     chrom
-                )));
+                ),
+                options.clip
+            ));
             }
         };
         // Make a new id for the chromosome

--- a/bigtools/src/bbi/beddata.rs
+++ b/bigtools/src/bbi/beddata.rs
@@ -368,7 +368,7 @@ mod tests {
                 Ok(())
             }
         }
-        let mut start_processing = |_: String| Ok(TestBBIDataProcessor::create(()));
+        let mut start_processing = |_: String| Ok(Some(TestBBIDataProcessor::create(())));
         let mut advance = |p: TestBBIDataProcessor| {
             counts.push(p.count);
             let _ = p.destroy();

--- a/bigtools/src/bbi/beddata.rs
+++ b/bigtools/src/bbi/beddata.rs
@@ -91,7 +91,7 @@ impl<S: StreamingBedValues> BBIDataSource for BedParserStreamingIterator<S> {
 
     fn process_to_bbi<
         P: BBIDataProcessor<Value = Self::Value>,
-        StartProcessing: FnMut(String) -> Result<P, ProcessDataError>,
+        StartProcessing: FnMut(String) -> Result<Option<P>, ProcessDataError>,
         Advance: FnMut(P),
     >(
         &mut self,

--- a/bigtools/src/bbi/bigbedwrite.rs
+++ b/bigtools/src/bbi/bigbedwrite.rs
@@ -260,7 +260,7 @@ async fn process_val(
             current_val.start, current_val.end
         )));
     }
-    if current_val.start >= chrom_length {
+    if current_val.end >= chrom_length {
         return Err(ProcessDataError::InvalidInput(format!(
             "Invalid bed: `{}` is greater than the chromosome ({}) length ({})",
             current_val.start, chrom, chrom_length

--- a/bigtools/src/utils/cli.rs
+++ b/bigtools/src/utils/cli.rs
@@ -63,6 +63,12 @@ pub struct BBIWriteArgs {
     #[arg(long)]
     #[arg(default_value_t = false)]
     pub inmemory: bool,
+
+    /// If set, just issue warning messages rather than dying if bedgraph
+    /// file contains chromosomes that are not in the chrom.sizes file.
+    #[arg(long)]
+    #[arg(default_value_t = false)]
+    pub clip: bool,
 }
 
 macro_rules! compat_replace_mut {

--- a/bigtools/src/utils/cli/bedgraphtobigwig.rs
+++ b/bigtools/src/utils/cli/bedgraphtobigwig.rs
@@ -35,9 +35,15 @@ pub struct BedGraphToBigWigArgs {
 
     /// If set, indicates that only a single pass should be done on the input file. This is most useful
     /// on large files in order to reduce total time. This automatically happens when the input is `stdin`.
-    #[arg(long)]
+    #[arg(short = 'c', long)]
     #[arg(default_value_t = false)]
     pub single_pass: bool,
+
+    /// If set, just issue warning messages rather than dying if bedgraph
+    /// file contains chromosomes that are not in the chrom.sizes file.
+    #[arg(long)]
+    #[arg(default_value_t = false)]
+    pub clip: bool,
 
     #[command(flatten)]
     pub write_args: BBIWriteArgs,
@@ -46,6 +52,7 @@ pub struct BedGraphToBigWigArgs {
 pub fn bedgraphtobigwig(args: BedGraphToBigWigArgs) -> Result<(), Box<dyn Error>> {
     let bedgraphpath = args.bedgraph;
     let chrom_map = args.chromsizes;
+    let clip = args.clip;
     let bigwigpath = args.output;
     let nthreads = args.write_args.nthreads;
     let input_sort_type = match args.write_args.sorted.as_ref() {

--- a/bigtools/src/utils/cli/bedgraphtobigwig.rs
+++ b/bigtools/src/utils/cli/bedgraphtobigwig.rs
@@ -39,12 +39,6 @@ pub struct BedGraphToBigWigArgs {
     #[arg(default_value_t = false)]
     pub single_pass: bool,
 
-    /// If set, just issue warning messages rather than dying if bedgraph
-    /// file contains chromosomes that are not in the chrom.sizes file.
-    #[arg(long)]
-    #[arg(default_value_t = false)]
-    pub clip: bool,
-
     #[command(flatten)]
     pub write_args: BBIWriteArgs,
 }
@@ -52,7 +46,6 @@ pub struct BedGraphToBigWigArgs {
 pub fn bedgraphtobigwig(args: BedGraphToBigWigArgs) -> Result<(), Box<dyn Error>> {
     let bedgraphpath = args.bedgraph;
     let chrom_map = args.chromsizes;
-    let clip = args.clip;
     let bigwigpath = args.output;
     let nthreads = args.write_args.nthreads;
     let input_sort_type = match args.write_args.sorted.as_ref() {
@@ -94,6 +87,7 @@ pub fn bedgraphtobigwig(args: BedGraphToBigWigArgs) -> Result<(), Box<dyn Error>
     outb.options.input_sort_type = input_sort_type;
     outb.options.block_size = args.write_args.block_size;
     outb.options.inmemory = args.write_args.inmemory;
+    outb.options.clip = args.write_args.clip;
 
     let runtime = if nthreads == 1 {
         outb.options.channel_size = 0;

--- a/bigtools/src/utils/cli/bigwigmerge.rs
+++ b/bigtools/src/utils/cli/bigwigmerge.rs
@@ -366,10 +366,6 @@ impl BBIDataSource for ChromGroupReadImpl {
                 Some(Ok((chrom, _, mut group))) => {
                     let mut p = match start_processing(chrom) {
                         Ok(processor) => processor,
-                        Err(ProcessDataError::InvalidChromosome(_, true)) => {
-                            // clip is true, so continue
-                            continue;
-                        },
                         Err(e) => return Err(e.into()),
                     };
 

--- a/bigtools/src/utils/cli/bigwigmerge.rs
+++ b/bigtools/src/utils/cli/bigwigmerge.rs
@@ -364,7 +364,14 @@ impl BBIDataSource for ChromGroupReadImpl {
                 self.iter.next();
             match next {
                 Some(Ok((chrom, _, mut group))) => {
-                    let mut p = start_processing(chrom)?;
+                    let mut p = match start_processing(chrom) {
+                        Ok(processor) => processor,
+                        Err(ProcessDataError::InvalidChromosome(_, true)) => {
+                            // clip is true, so continue
+                            continue;
+                        },
+                        Err(e) => return Err(e.into()),
+                    };
 
                     loop {
                         let current_val = match group.iter.next() {

--- a/bigtools/src/utils/cli/bigwigmerge.rs
+++ b/bigtools/src/utils/cli/bigwigmerge.rs
@@ -351,7 +351,7 @@ impl BBIDataSource for ChromGroupReadImpl {
 
     fn process_to_bbi<
         P: BBIDataProcessor<Value = Self::Value>,
-        StartProcessing: FnMut(String) -> Result<P, ProcessDataError>,
+        StartProcessing: FnMut(String) -> Result<Option<P>, ProcessDataError>,
         Advance: FnMut(P),
     >(
         &mut self,


### PR DESCRIPTION
Hey @jackh726!

As mentioned in #56, this PR adds a new option to the `bedgraphtobigwig` binary that will "skip" any chromosomes in the `.bedGraph` file that are not represented in the given `chrom.sizes` file. This functionality is inspired by the kent utils `-clip` option in [`wigToBigWig`](https://github.com/ucscGenomeBrowser/kent/blob/be493d28f90207835c1dc59a816f5b25bc05a322/src/utils/wigToBigWig/wigToBigWig.c#L49).

I appreciate you letting me take a stab at this. Currently... it's unfinished. It is not working properly, but I thought I'd open it and get your immediate feedback. I think I'm getting stuck in an infinite loop and will continue working. 

Anyways, after getting my bearings, I was able to quickly add `--clip` to `BBIWriteOptions`. I had some troubles deciding how to implement the skip logic, however.

I believe that I was able to find the source of the error... The `do_read` that gets passed as the `start_processing` argument in `process_to_bbi` [will return](https://github.com/jackh726/bigtools/blob/8f2dd8e0f5edbbf907539df8cb6ebd23f45148d1/bigtools/src/bbi/bbiwrite.rs#L827) the `ProcessDataError::InvalidChromosome` error if the chromosome is not found in `chrom.sizes`. I had three ideas to go forward:

1. Add a fourth argument called `clip` to the [`process_to_bbi` function in the `BBIDataSource` trait](https://github.com/jackh726/bigtools/blob/8f2dd8e0f5edbbf907539df8cb6ebd23f45148d1/bigtools/src/bbi/bbiwrite.rs#L573). Then, inside `match` the error and skip if `clip` is true. I didn't like this since it felt too specific for the trait.
2. Add a new error called `ProcessDataError::ClippedChromosome`. If `clip` is true, return this instead of the current `ProcessDataError::ClippedChromosome`. Likewise, this can be matched inside `process_to_bbi` and enable a "skip"-like feature. This felt weird since its not really an error.
3. Add a boolean field to `ProcessDataError::InvalidChromosome`. Again, `match` on this error and that field being true, skip the chromosome.

I went with option three since it seemed the least hacky and most idiomatic/rusty way. I'm curious to your thoughts on this and it seems the real trick is just getting those `BBIWriteOptions` into `process_to_bbi`.

Will continue working on the infinite loop, so stay tuned. Thank you!