### PR TITLE
Support building with maturin 1.8.0.

### DIFF
--- a/pybigtools/pyproject.toml
+++ b/pybigtools/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=1.0,<2.0"]
+requires = ["maturin>=1.4,<2.0"]
 build-backend = "maturin"
 
 [project]
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
 ]
+dynamic = ["version"]
 dependencies = [
     "numpy"
 ]


### PR DESCRIPTION
Building pybigtools with maturing 1.8.0 failed with:
  Caused by: `project.version` field is required in pyproject.toml unless it is present in the `project.dynamic` list

`project.dynamic` is already supported since maturin 1.4:
  https://github.com/PyO3/maturin/issues/2416