### PR TITLE
Automatically recognise `/dev/stdin` as stdin in bedgraphtobigwig and…

### DIFF
--- a/bigtools/src/utils/cli/bedgraphtobigwig.rs
+++ b/bigtools/src/utils/cli/bedgraphtobigwig.rs
@@ -18,7 +18,7 @@ use super::BBIWriteArgs;
     long_about = "Converts an input bedGraph to a bigWig. Can be multi-threaded for substantial speedups. Note that ~11 temporary files are created/maintained."
 )]
 pub struct BedGraphToBigWigArgs {
-    /// The bedgraph to convert to a bigwig. Can use `-` or `stdin` to read from stdin.
+    /// The bedgraph to convert to a bigwig. Can use `-`, `stdin` or `/dev/stdin` to read from stdin.
     pub bedgraph: String,
 
     /// A chromosome sizes file. Each line should be have a chromosome and its size in bases, separated by whitespace.
@@ -99,7 +99,7 @@ pub fn bedgraphtobigwig(args: BedGraphToBigWigArgs) -> Result<(), Box<dyn Error>
     };
 
     let allow_out_of_order_chroms = !matches!(outb.options.input_sort_type, InputSortType::ALL);
-    if bedgraphpath == "-" || bedgraphpath == "stdin" {
+    if bedgraphpath == "-" || bedgraphpath == "stdin" || bedgraphpath == "/dev/stdin" {
         let stdin = std::io::stdin().lock();
         let vals = BedParserStreamingIterator::from_bedgraph_file(stdin, allow_out_of_order_chroms);
         outb.write(vals, runtime)?;

--- a/bigtools/src/utils/cli/bedtobigbed.rs
+++ b/bigtools/src/utils/cli/bedtobigbed.rs
@@ -21,7 +21,7 @@ use super::BBIWriteArgs;
     long_about = None,
 )]
 pub struct BedToBigBedArgs {
-    /// The bedGraph to convert to a bigbed.
+    /// The bed to convert to a bigbed. Can use `-`, `stdin` or `/dev/stdin` to read from stdin.
     pub bed: String,
 
     /// A chromosome sizes file. Each line should be have a chromosome and its size in bases, separated by whitespace.
@@ -108,7 +108,7 @@ pub fn bedtobigbed(args: BedToBigBedArgs) -> anyhow::Result<()> {
     };
 
     let allow_out_of_order_chroms = !matches!(outb.options.input_sort_type, InputSortType::ALL);
-    if bedpath == "-" || bedpath == "stdin" {
+    if bedpath == "-" || bedpath == "stdin" || bedpath == "/dev/stdin" {
         if let Some(file) = args.autosql.as_ref() {
             outb.autosql = Some(std::fs::read_to_string(file)?);
         }


### PR DESCRIPTION
… bedtobigwig.