### PR TITLE
Add `with_info` to BigBedRead and inner reader unwrapping methods

### DIFF
--- a/bigtools/src/bbi/bigbedread.rs
+++ b/bigtools/src/bbi/bigbedread.rs
@@ -146,6 +146,21 @@ impl<R> BigBedRead<R> {
     pub fn chroms(&self) -> &[ChromInfo] {
         &self.info.chrom_info
     }
+
+    /// Returns a reference to the underlying reader.
+    pub fn get_ref(&self) -> &R {
+        &self.read
+    }
+
+    /// Returns a mutable reference to the underlying reader.
+    pub fn get_mut(&mut self) -> &mut R {
+        &mut self.read
+    }
+
+    /// Consumes this `BigWigRead`, returning the underlying reader.
+    pub fn into_inner(self) -> R {
+        self.read
+    }
 }
 
 impl BigBedRead<ReopenableFile> {
@@ -188,6 +203,11 @@ impl<R: BBIFileRead> BigBedRead<R> {
         }
 
         Ok(BigBedRead { info, read })
+    }
+
+    /// Does *not* check if the passed `R` matches the provided info (including if the `R` is a bigBed at all!)
+    pub fn with_info(info: BBIFileInfo, read: R) -> Self {
+        BigBedRead { info, read }
     }
 
     /// Reads the autosql from this bigBed

--- a/bigtools/src/bbi/bigbedread.rs
+++ b/bigtools/src/bbi/bigbedread.rs
@@ -147,16 +147,6 @@ impl<R> BigBedRead<R> {
         &self.info.chrom_info
     }
 
-    /// Returns a reference to the underlying reader.
-    pub fn get_ref(&self) -> &R {
-        &self.read
-    }
-
-    /// Returns a mutable reference to the underlying reader.
-    pub fn get_mut(&mut self) -> &mut R {
-        &mut self.read
-    }
-
     /// Consumes this `BigWigRead`, returning the underlying reader.
     pub fn into_inner(self) -> R {
         self.read

--- a/bigtools/src/bbi/bigwigread.rs
+++ b/bigtools/src/bbi/bigwigread.rs
@@ -192,16 +192,6 @@ impl<R> BigWigRead<R> {
         &self.info.chrom_info
     }
 
-    /// Returns a reference to the underlying reader.
-    pub fn get_ref(&self) -> &R {
-        &self.read
-    }
-
-    /// Returns a mutable reference to the underlying reader.
-    pub fn get_mut(&mut self) -> &mut R {
-        &mut self.read
-    }
-
     /// Consumes this `BigWigRead`, returning the underlying reader.
     pub fn into_inner(self) -> R {
         self.read

--- a/bigtools/src/bbi/bigwigread.rs
+++ b/bigtools/src/bbi/bigwigread.rs
@@ -191,6 +191,21 @@ impl<R> BigWigRead<R> {
     pub fn chroms(&self) -> &[ChromInfo] {
         &self.info.chrom_info
     }
+
+    /// Returns a reference to the underlying reader.
+    pub fn get_ref(&self) -> &R {
+        &self.read
+    }
+
+    /// Returns a mutable reference to the underlying reader.
+    pub fn get_mut(&mut self) -> &mut R {
+        &mut self.read
+    }
+
+    /// Consumes this `BigWigRead`, returning the underlying reader.
+    pub fn into_inner(self) -> R {
+        self.read
+    }
 }
 
 impl BigWigRead<ReopenableFile> {


### PR DESCRIPTION
The only methods I currently need are `with_info` and `into_inner`. 

I included `get_ref` and `get_mut` for completeness, but `get_ref` appears to be identical to the existing `inner_read` method. I can remove them.