### PR TITLE
Update libdeflater compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,18 +543,18 @@ checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "libdeflate-sys"
-version = "0.13.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c301042beb41d94bc0f8dc667712f8fa8c42d3ea058dd7a71bed3fee8370c75e"
+checksum = "72753e0008ea87963d2f0770042d0df7abe51fafbb8dcaf618ac440f2f1fec0a"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "libdeflater"
-version = "0.13.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea90e8df8addcafac4c8737aabf1597f2e83320d58552d8594a52f74cbf24d2e"
+checksum = "d1ee41cf6fb1bb6030dfb59ffb7bc01ab26aade44142084c87f0fc7a1658fe71"
 dependencies = [
  "libdeflate-sys",
 ]

--- a/bigtools/Cargo.toml
+++ b/bigtools/Cargo.toml
@@ -21,8 +21,8 @@ serde = { version = "1", features = ["derive"], optional = true }
 clap = { version = "4.3", optional = true, features = ["derive"] }
 itertools = { version = "0.10", optional = true }
 bincode = { version = "1.3", optional = true }
-attohttpc = { version = "0.25", optional = true, default_features = false, features = ["tls-rustls-native-roots"] }
-libdeflater = "0.13"
+attohttpc = { version = "0.25", optional = true, default-features = false, features = ["tls-rustls-native-roots"] }
+libdeflater = "1"
 thiserror = "1"
 anyhow = { version = "1", optional = true }
 ryu = { version = "1.0", optional = true }

--- a/pybigtools/Cargo.toml
+++ b/pybigtools/Cargo.toml
@@ -9,7 +9,7 @@ name = "pybigtools"
 crate-type = ["cdylib"]
 
 [dependencies]
-bigtools = { version = "0.5.7-dev", path = "../bigtools", default_features = false, features = ["read", "write"] }
+bigtools = { version = "0.5.7-dev", path = "../bigtools", default-features = false, features = ["read", "write"] }
 url = "2.5.0"
 tokio = { version = "1.41.0", features = ["rt", "rt-multi-thread"] }
 futures = { version = "0.3.1", features = ["thread-pool"] }


### PR DESCRIPTION
This updates the Rust crate dependency from libdeflater 0.13 to the current 1.x line and switches deprecated Cargo key syntax from default_features to default-features.\n\nThe dependency update avoids version conflicts when bigtools is used in workspaces that already depend on libdeflater 1.x through other bioinformatics crates.\n\nVerification run:\n\n```\ncargo check -p bigtools --no-default-features --features read,write\n```